### PR TITLE
Automated Long Term Memory Concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,18 @@ If instead you enable `Always Separate`, marked summaries will always be put in 
 - You can also select where in your context to inject `long-term` summaries, or choose not to inject them at all (in which case you would need to use the `{{qm-long-term-memory}}` to manually put them into your context).
 - If you select the same injection position for both `short-term` and `long-term`, then `long-term` will be placed before `short-term`.
 
+#### Automated Long-term Memory
+- This section controls how the extension automatically identifies and tags important summaries as `long-term` memories using an LLM.
+- `Process All Memories` triggers an immediate analysis of all summaries. When the scope is set to `Process All Memories`, everything is sent to the LLM in a single batch. For other scope settings, messages are processed in batches using the `Process Last N Memories` value as the chunk size.
+- The `Importance Threshold` controls how selective the LLM is when deciding what to preserve. `High` keeps only major turning points and critical revelations. `Medium` keeps significant developments and key decisions. `Low` preserves most meaningful content. `None` adds no additional guidance beyond the base prompt. These are based on instructions to the LLM, and as such, subject to the skill of the LLM to understand how to determine critical and significant.
+- The `Scope` setting determines which messages are included when analysis is triggered — either automatically or via the message button:
+  - `Process All Memories` sends every summarized message to the LLM in a single batch.
+  - `Process New Memories` only analyzes messages from the most recent `long-term` memory entry up to the latest message, making it efficient for incremental updates.
+  - `Process Last N Memories` analyzes only the last N summarized messages, useful for large chats where processing everything would be expensive.
+- `Allow Long-Term Memory Removal` allows the LLM to also un-mark previously tagged `long-term` memories that are no longer considered important in the broader context. When disabled, analysis can only add new `long-term` memories, never remove existing ones.
+- `Auto-Process Long-Term Memory` runs analysis automatically after every N new messages using the scope selected above. For example, with scope set to `Process Last 50 Memories` and interval set to `25`, the last 50 messages are analyzed every 25 messages — overlap is intentional and helps ensure nothing important is missed.
+- The `Memory Interval` controls how often the automatic analysis triggers (minimum 10). Note that this controls *how often* analysis runs, not *how many* messages are analyzed — that is determined by the scope setting.
+
 #### Misc.
 - This section contains a few miscellaneous settings.
 - `Debug Mode` cause the extension to output additional logs in your browser console, useful for reporting bugs.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 - [Tips & Tricks](#tips--tricks)
 - [Troubleshooting](#troubleshooting)
 - [Reporting an Issue](#reporting-an-issue)
-- [Contributing](#contributing)
 - [Known Issues](#known-issues)
 
 ### Version Requirement
@@ -297,11 +296,6 @@ The easiest and quickest way to help me reproduce the bug is to provide the foll
 Then record every single action you take up until you see something unexpected happen along with what you **expected** to happen instead. 
 You can revert settings to default by scrolling to the bottom of the config and clicking `Revert Settings`.
 8. Any errors in the browser console or ST terminal (you can access your console with F12 in most browsers). These can be included in the steps from #7.
-
-### Contributing
-- If you would like to contribute to this extension, please submit a PR to the `dev` branch as that contains the most up-to-date version of the extension.
-- I would request that individual features be in their own separate PRs as larger PRs are much harder to review.
-- I won't take any PRs refactoring the whole extension. Yes I know everything is in one file, I'll get around to it eventually.
 
 ### Known Issues
 - Using the API tokenizer may cause lag when opening chats under certain circumstances, cause currently unknown.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [Tips & Tricks](#tips--tricks)
 - [Troubleshooting](#troubleshooting)
 - [Reporting an Issue](#reporting-an-issue)
+- [Contributing](#contributing)
 - [Known Issues](#known-issues)
 
 ### Version Requirement
@@ -294,6 +295,11 @@ The easiest and quickest way to help me reproduce the bug is to provide the foll
 Then record every single action you take up until you see something unexpected happen along with what you **expected** to happen instead. 
 You can revert settings to default by scrolling to the bottom of the config and clicking `Revert Settings`.
 8. Any errors in the browser console or ST terminal (you can access your console with F12 in most browsers). These can be included in the steps from #7.
+
+### Contributing
+- If you would like to contribute to this extension, please submit a PR to the `dev` branch as that contains the most up-to-date version of the extension.
+- I would request that individual features be in their own separate PRs as larger PRs are much harder to review.
+- I won't take any PRs refactoring the whole extension. Yes I know everything is in one file, I'll get around to it eventually.
 
 ### Known Issues
 - Using the API tokenizer may cause lag when opening chats under certain circumstances, cause currently unknown.

--- a/README.md
+++ b/README.md
@@ -112,6 +112,17 @@ If instead you enable `Always Separate`, marked summaries will always be put in 
 - You can also select where in your context to inject `long-term` summaries, or choose not to inject them at all (in which case you would need to use the `{{qm-long-term-memory}}` to manually put them into your context).
 - If you select the same injection position for both `short-term` and `long-term`, then `long-term` will be placed before `short-term`.
 
+#### Automated Long-term Memory
+- This section controls how the extension automatically identifies and tags important summaries as `long-term` memories using an LLM.
+- For bulk processing of memories use the `Edit Memory` button and select the memories to be processed. 
+- The `Scope` setting determines which messages are included when analysis is triggered — either automatically or via the message button:
+  - `Process All Memories` sends every summarized message to the LLM.
+  - `Process New Memories` only analyzes messages from the most recent `long-term` memory entry up to the latest message, making it efficient for incremental updates.
+  - `Process Last N Memories` analyzes only the last N summarized messages, useful for large chats where processing everything would be expensive.
+- `Allow Long-Term Memory Removal` allows the LLM to also un-mark previously tagged `long-term` memories that are no longer considered important in the broader context. When disabled, analysis can only add new `long-term` memories, never remove existing ones.
+- `Auto-Process Long-Term Memory` runs analysis automatically after every N new messages using the scope selected above. For example, with scope set to `Process Last 50 Memories` and interval set to `25`, the last 50 messages are analyzed every 25 messages — overlap is intentional and helps ensure nothing important is missed.
+- The `Memory Interval` controls how often the automatic analysis triggers (minimum 10). Note that this controls *how often* analysis runs, not *how many* messages are analyzed — that is determined by the scope setting.
+
 #### Misc.
 - This section contains a few miscellaneous settings.
 - `Debug Mode` cause the extension to output additional logs in your browser console, useful for reporting bugs.

--- a/README.md
+++ b/README.md
@@ -113,9 +113,8 @@ If instead you enable `Always Separate`, marked summaries will always be put in 
 
 #### Automated Long-term Memory
 - This section controls how the extension automatically identifies and tags important summaries as `long-term` memories using an LLM.
-- `Process All Memories` triggers an immediate analysis of all summaries. When the scope is set to `Process All Memories`, everything is sent to the LLM in a single batch. For other scope settings, messages are processed in batches using the `Process Last N Memories` value as the chunk size.
 - The `Scope` setting determines which messages are included when analysis is triggered — either automatically or via the message button:
-  - `Process All Memories` sends every summarized message to the LLM in a single batch.
+  - `Process All Memories` sends every summarized message to the LLM.
   - `Process New Memories` only analyzes messages from the most recent `long-term` memory entry up to the latest message, making it efficient for incremental updates.
   - `Process Last N Memories` analyzes only the last N summarized messages, useful for large chats where processing everything would be expensive.
 - `Allow Long-Term Memory Removal` allows the LLM to also un-mark previously tagged `long-term` memories that are no longer considered important in the broader context. When disabled, analysis can only add new `long-term` memories, never remove existing ones.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,6 @@ If instead you enable `Always Separate`, marked summaries will always be put in 
 #### Automated Long-term Memory
 - This section controls how the extension automatically identifies and tags important summaries as `long-term` memories using an LLM.
 - `Process All Memories` triggers an immediate analysis of all summaries. When the scope is set to `Process All Memories`, everything is sent to the LLM in a single batch. For other scope settings, messages are processed in batches using the `Process Last N Memories` value as the chunk size.
-- The `Importance Threshold` controls how selective the LLM is when deciding what to preserve. `High` keeps only major turning points and critical revelations. `Medium` keeps significant developments and key decisions. `Low` preserves most meaningful content. `None` adds no additional guidance beyond the base prompt. These are based on instructions to the LLM, and as such, subject to the skill of the LLM to understand how to determine critical and significant.
 - The `Scope` setting determines which messages are included when analysis is triggered — either automatically or via the message button:
   - `Process All Memories` sends every summarized message to the LLM in a single batch.
   - `Process New Memories` only analyzes messages from the most recent `long-term` memory entry up to the latest message, making it efficient for incremental updates.

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ If instead you enable `Always Separate`, marked summaries will always be put in 
 
 #### Automated Long-term Memory
 - This section controls how the extension automatically identifies and tags important summaries as `long-term` memories using an LLM.
+- For bulk processing of memories use the `Edit Memory` button and select the memories to be processed. 
 - The `Scope` setting determines which messages are included when analysis is triggered — either automatically or via the message button:
   - `Process All Memories` sends every summarized message to the LLM.
   - `Process New Memories` only analyzes messages from the most recent `long-term` memory entry up to the latest message, making it efficient for incremental updates.

--- a/index.js
+++ b/index.js
@@ -3454,6 +3454,12 @@ class SummaryQueue {
             error(`Text to summarize (${token_size}) exceeds summary context size (${context_size}).`);
         }
 
+        let connection = ctx.ConnectionManagerRequestService.getConnection(profile);
+        console.warn('connection properties:', connection);
+        if (!connection) {
+            throw new Error(`No connection found for profile: ${profile}`);
+        }
+
         let result = await ctx.ConnectionManagerRequestService.sendRequest(profile, messages)
 
         // trim incomplete sentences if set in ST settings

--- a/index.js
+++ b/index.js
@@ -3454,36 +3454,6 @@ class SummaryQueue {
             error(`Text to summarize (${token_size}) exceeds summary context size (${context_size}).`);
         }
 
-        let connection = ctx.ConnectionManagerRequestService.getProfile(profile);
-        if (!connection) {
-            throw new Error(`No connection found for profile: ${profile}`);
-        }
-        console.warn('[summarize_text] connection profile:', connection);
-        console.warn('[summarize_text] overridePayload fields (from profile):', {
-            custom_url: connection['api-url'],
-            vertexai_region: connection['api-url'],
-            zai_endpoint: connection['api-url'],
-            siliconflow_endpoint: connection['api-url'],
-            model: connection.model,
-            preset: connection.preset,
-            proxy: connection.proxy,
-        });
-        console.warn('[summarize_text] chatCompletionSettings (relevant fields):', {
-            chat_completion_source: ctx.chatCompletionSettings?.chat_completion_source,
-            custom_url: ctx.chatCompletionSettings?.custom_url,
-            custom_include_body: ctx.chatCompletionSettings?.custom_include_body,
-            custom_exclude_body: ctx.chatCompletionSettings?.custom_exclude_body,
-            custom_include_headers: ctx.chatCompletionSettings?.custom_include_headers,
-        });
-
-        const presetManager = ctx.getPresetManager?.('openai');
-        const preset = presetManager?.getCompletionPresetByName?.(connection.preset);
-        console.warn('[summarize_text] preset fields (chat_completion_source may override settings):', {
-            name: preset?.name,
-            chat_completion_source: preset?.chat_completion_source,
-            temperature: preset?.temperature,
-        });
-
         let result = await ctx.ConnectionManagerRequestService.sendRequest(profile, messages)
 
         // trim incomplete sentences if set in ST settings

--- a/index.js
+++ b/index.js
@@ -1695,7 +1695,7 @@ class MemoryEditInterface {
             "title": "Summaries automatically tagged for long-term memory by automated analysis",
             "display": "Long-Term (Auto)",
             "check": (msg) => get_data(msg, 'remember_auto'),
-            "default": false,
+            "default": true,
             "count": 0
         },
         "excluded": {
@@ -1895,6 +1895,7 @@ class MemoryEditInterface {
             // Get nessages that are manual and not auto and toggle them normally with remember_message_toggle
             let manual_remember = selection.filter(i => !get_data(this.ctx.chat[i], 'remember_auto') || get_data(this.ctx.chat[i], 'remember'));
             if (manual_remember.length > 0) remember_message_toggle(manual_remember);
+
             // For auto-only messages we can only toggle them to "false"
             let auto_only = selection.filter(i => get_data(this.ctx.chat[i], 'remember_auto') && !get_data(this.ctx.chat[i], 'remember'));
             if (auto_only.length > 0) remember_auto_message_toggle(auto_only, false);

--- a/index.js
+++ b/index.js
@@ -95,12 +95,14 @@ Following is the message to summarize:
 `
 const default_automated_memory_prompt = `You are a narrative analysis assistant for an ongoing fictional roleplay. Your task: decide which message summaries should be preserved as long-term memories.
 
-The key test for each summary: does it introduce a fact, name, relationship detail, backstory, or situation change that would be LOST if this summary were removed? If removing it would leave no gap in the story's record, it is not worth preserving.
+The key test for each summary: does it introduce a fact, name, relationship detail, backstory, emotional development, or situation change that would be LOST if this summary were removed? If removing it would leave no gap in the story's record, it is not worth preserving.
 
 PRESERVE messages that introduce new information such as:
 - A character's name, identity, or backstory being revealed
 - New facts about a character's situation, history, or motivations
 - Relationship developments (friendships, conflicts, romance, alliances, betrayals, trust shifts)
+- Characters bonding, warming up to each other, or forming connections — or the opposite: growing hostile, distrustful, or distant — even through casual interaction
+- Characters observing or reacting to dynamics between others (e.g., a parent noticing someone bonding with their child, someone witnessing a confrontation or slight)
 - Events that change the characters' situation or the story's direction
 - Key decisions or commitments made by characters
 - New locations, setting details, or world-building facts
@@ -110,10 +112,10 @@ PRESERVE messages that introduce new information such as:
 - Deaths, departures, or arrivals
 
 EXCLUDE messages that are:
-- Conversational scaffolding — questions, comments, small talk, or reactions that don't themselves contain new facts (even if they prompt a reveal in the next message)
+- Conversational scaffolding — questions, comments, or small talk that don't themselves reveal new facts or develop relationships (even if they prompt a reveal in the next message)
 - Redundant with another already-remembered summary (marked Long-term: Yes)
 - Purely transitional actions with no new narrative content
-- Minor reactions or internal thoughts that don't reveal anything new
+- Minor reactions or internal thoughts that don't reveal anything new or shift any dynamic
 
 This is an ongoing story — you cannot know for certain what will matter later. When a summary contains new information, preserve it even if it seems minor now.
 

--- a/index.js
+++ b/index.js
@@ -137,7 +137,6 @@ const default_settings = {
 
     // summarization settings
     prompt: default_prompt,
-    detailed_prompt: default_detailed_prompt,
     automated_memory_prompt: default_automated_memory_prompt,
     summary_prompt_macros: default_summary_macros,  // macros for the summary prompt interface
     prompt_role: extension_prompt_roles.SYSTEM,
@@ -2329,11 +2328,7 @@ class SummaryPromptEditInterface {
             <h3>Summary Prompt</h3>
             <i class="fa-solid fa-info-circle" style="margin-right: 1em" title="Customize the prompt used for summarizing messages."></i>
             <button id="preview_summary_prompt" class="menu_button fa-solid fa-eye margin0" title="Preview current summary prompt (the exact text that will be sent to the model)"></button>
-            <select id="restore_prompt_preset" class="text_pole inline_setting" title="Load a prompt preset">
-                <option value="" selected disabled>Load Preset</option>
-                <option value="default">Default</option>
-                <option value="detailed">Detailed</option>
-            </select>
+            <button id="restore_default_prompt" class="menu_button fa-solid fa-recycle margin0 red_button" title="Restore the default prompt"></button>
 
             <label class="flex-container alignItemsCenter" title="Role used for the summary prompt" style="margin-left: auto;">
                 <span>Role: </span>
@@ -2498,7 +2493,7 @@ class SummaryPromptEditInterface {
         this.$content = $(this.popup.content)
         this.$buttons = this.$content.find('.popup-controls')
         this.$preview = this.$content.find('#preview_summary_prompt')
-        this.$restore = this.$content.find('#restore_prompt_preset')
+        this.$restore = this.$content.find('#restore_default_prompt')
         this.$definitions = this.$content.find('#macro_definitions')
         this.$add_macro = this.$content.find('#add_macro')
         this.$open_macros = this.$content.find('.open_macros')
@@ -2516,11 +2511,8 @@ class SummaryPromptEditInterface {
         // buttons
         this.$preview.on('click', () => this.preview_prompt())
         this.$add_macro.on('click', () => this.new_macro())
-        this.$restore.on('change', (e) => {
-            const presets = { default: default_settings["prompt"], detailed: default_settings["detailed_prompt"] };
-            const selected = e.target.value;
-            if (presets[selected]) this.$prompt.val(presets[selected]);
-            e.target.value = '';  // reset to "Load Preset" placeholder
+        this.$restore.on('click', () => {
+            this.$prompt.val(default_settings["prompt"]);
         })
         this.$open_macros.on('click', () => {
             this.$content.find('.toggle-macro').toggle()

--- a/index.js
+++ b/index.js
@@ -1424,7 +1424,7 @@ function get_message_div(index) {
 }
 function get_summary_style_class(message) {
     let include = get_data(message, 'include');
-    let remember = get_data(message, 'remember');
+    let remember = get_data(message, 'remember') || get_data(message, 'remember_auto');
     let exclude = get_data(message, 'exclude');  // force-excluded by user
     let lagging = get_data(message, 'lagging');  // not injected yet
 
@@ -1691,6 +1691,13 @@ class MemoryEditInterface {
             "default": true,
             "count": 0
         },
+        "long_term_auto": {
+            "title": "Summaries automatically tagged for long-term memory by automated analysis",
+            "display": "Long-Term (Auto)",
+            "check": (msg) => get_data(msg, 'remember_auto'),
+            "default": false,
+            "count": 0
+        },
         "excluded": {
             "title": "Summaries not in short-term or long-term memory",
             "display": "Forgot",
@@ -1884,7 +1891,13 @@ class MemoryEditInterface {
 
         // bulk action buttons
         this.$content.find(`#bulk_remember`).on('click', () => {
-            remember_message_toggle(this.get_sorted_selection())
+            let selection = this.get_sorted_selection();
+            // Get nessages that are manual and not auto and toggle them normally with remember_message_toggle
+            let manual_remember = selection.filter(i => !get_data(this.ctx.chat[i], 'remember_auto') || get_data(this.ctx.chat[i], 'remember'));
+            if (manual_remember.length > 0) remember_message_toggle(manual_remember);
+            // For auto-only messages we can only toggle them to "false"
+            let auto_only = selection.filter(i => get_data(this.ctx.chat[i], 'remember_auto') && !get_data(this.ctx.chat[i], 'remember'));
+            if (auto_only.length > 0) remember_auto_message_toggle(auto_only, false);
             this.update_table()
         })
         this.$content.find(`#bulk_exclude`).on('click', () => {
@@ -1924,7 +1937,11 @@ class MemoryEditInterface {
         })
         this.$content.on("click", `tr .${remember_button_class}`, function () {
             let message_id = Number($(this).closest('tr').attr('message_id'));  // get the message ID from the row's "message_id" attribute
-            remember_message_toggle(message_id);
+            if (get_data(self.ctx.chat[message_id], 'remember_auto')) {
+                remember_auto_message_toggle(message_id, false);
+            } else {
+                remember_message_toggle(message_id);
+            }
             self.update_table()
         });
         this.$content.on("click", `tr .${forget_button_class}`, function () {
@@ -2023,6 +2040,7 @@ class MemoryEditInterface {
         let filter_no_summary = this.filter_bar.no_summary.filtered()
         let filter_short_term = this.filter_bar.short_term.filtered()
         let filter_long_term = this.filter_bar.long_term.filtered()
+        let filter_long_term_auto = this.filter_bar.long_term_auto.filtered()
         let filter_excluded = this.filter_bar.excluded.filtered()
         let filter_force_excluded = this.filter_bar.force_excluded.filtered()
         let filter_edited = this.filter_bar.edited.filtered()
@@ -2037,6 +2055,7 @@ class MemoryEditInterface {
 
             if (filter_short_term           && this.filter_bar.short_term.check(msg)) include = true;
             else if (filter_long_term       && this.filter_bar.long_term.check(msg)) include = true;
+            else if (filter_long_term_auto  && this.filter_bar.long_term_auto.check(msg)) include = true;
             else if (filter_no_summary      && this.filter_bar.no_summary.check(msg)) include = true;
             else if (filter_errors          && this.filter_bar.errors.check(msg)) include = true;
             else if (filter_excluded        && this.filter_bar.excluded.check(msg)) include = true;
@@ -3595,6 +3614,7 @@ async function remember_message_toggle(indexes=null, value=null) {
         let message = context.chat[index]
         set_data(message, 'remember', value);
         set_data(message, 'exclude', false);  // regardless, remove excluded flag
+        if (!value) set_data(message, 'remember_auto', false);  // clearing remember also clears auto
 
         let memory = get_data(message, 'memory')
         if (value && !memory) {
@@ -3664,7 +3684,7 @@ function collect_long_term_memory_summaries(scope, end_index) {
     // Start from the most recent long-term memory (searching back from last_index)
     if (scope === 'new') {
         for (let i = last_index; i >= 0; i--) {
-            if (get_data(chat[i], 'remember')) {
+            if (get_data(chat[i], 'remember') || get_data(chat[i], 'remember_auto')) {
                 start_index = i;
                 break;
             }
@@ -3690,7 +3710,7 @@ function collect_long_term_memory_summaries(scope, end_index) {
     for (let i = start_index; i <= last_index; i++) {
         let memory = get_data(chat[i], 'memory');
         if (!memory) continue;
-        let is_remembered = get_data(chat[i], 'remember') ? 'Yes' : 'No';
+        let is_remembered = (get_data(chat[i], 'remember') || get_data(chat[i], 'remember_auto')) ? 'Yes' : 'No';
         summary_lines.push(`Message ${i} | Long-term: ${is_remembered} | Summary: ${memory}`);
         valid_indexes.push(i);
     }
@@ -4066,7 +4086,7 @@ function update_message_inclusion_flags() {
             }
 
             // consider this for short term memories as long as we aren't separating long-term or (if we are), this isn't a long-term
-            if (!separate_long_term || !get_data(message, 'remember')) {
+            if (!separate_long_term || (!get_data(message, 'remember') && !get_data(message, 'remember_auto'))) {
                 let new_short_token_size = short_token_size + sep_size + count_tokens(get_memory(message))
                 if (new_short_token_size > short_token_limit) {  // over context limit
                     short_limit_reached = true;
@@ -4079,7 +4099,7 @@ function update_message_inclusion_flags() {
         }
 
         // if the short-term limit has been reached (or we are separating), check the long-term limit.
-        let remember = get_data(message, 'remember');
+        let remember = get_data(message, 'remember') || get_data(message, 'remember_auto');
         if (!long_limit_reached && remember) {  // long-term limit hasn't been reached yet and the message was marked to be remembered
             let new_long_token_size = long_token_size + sep_size + count_tokens(get_memory(message))
             if (new_long_token_size > long_token_limit) {  // over context limit

--- a/index.js
+++ b/index.js
@@ -1903,7 +1903,7 @@ class MemoryEditInterface {
             await summaryQueue.summarize(this.get_sorted_selection());  // summarize in ascending order
         })
         this.$content.find(`#bulk_auto_ltm`).on('click', async () => {
-            await automated_long_term_memory(null, null, this.get_sorted_selection());
+            await automated_long_term_memory(this.get_sorted_selection());
             this.update_table();
         })
         this.$content.find(`#bulk_delete`).on('click', () => {
@@ -3717,15 +3717,14 @@ function build_ltm_summary_lines(indexes) {
     }
     return { summary_lines, valid_indexes };
 }
-async function automated_long_term_memory(scope_override=null, end_index=null, indexes=null) {
+async function automated_long_term_memory(indexes=null, end_index=null) {
     // Use an LLM to identify critically important summaries and mark them as long-term memories.
-    // scope_override: if provided, ignores the scope setting ('all', 'new', 'last_n')
-    // end_index: if provided, treat this as the latest message (inclusive) instead of the end of the chat
     // indexes: if provided, analyse exactly these message indexes instead of deriving a scope window
+    // end_index: if provided, treat this as the latest message (inclusive) instead of the end of the chat
     let chat = getContext().chat;
 
     // Step 1: Collect summaries — either from explicit indexes or by deriving a scope window
-    let scope_indexes = indexes ?? collect_ltm_scope_indexes(scope_override ?? get_settings('automated_memory_scope'), end_index);
+    let scope_indexes = indexes ?? collect_ltm_scope_indexes(get_settings('automated_memory_scope'), end_index);
     let { summary_lines, valid_indexes } = build_ltm_summary_lines(scope_indexes);
 
     if (summary_lines.length === 0) {

--- a/index.js
+++ b/index.js
@@ -93,13 +93,33 @@ Following is a history of messages for context:
 Following is the message to summarize:
 {{message}}
 `
-const default_automated_memory_prompt = `You are a narrative analysis assistant. Below is a list of message summaries from a fictional roleplay. Each line has this format: Message NUMBER | Long-term: Yes/No | Summary: TEXT
+const default_automated_memory_prompt = `You are a narrative analysis assistant for an ongoing fictional roleplay. Your task: decide which message summaries should be preserved as long-term memories. This is an ongoing story — you cannot know for certain what will matter later, so err on the side of preserving anything that could be referenced or built upon.
+
+PRESERVE messages that contain any of the following:
+- A new character appearing or being introduced
+- Characters meeting or interacting for the first time
+- Relationship developments (friendships, conflicts, romance, alliances, betrayals, trust shifts)
+- Plot-advancing events or actions that change the story's direction
+- Key decisions or commitments made by characters
+- Revelations, discoveries, or new information about characters or the world
+- New locations, setting changes, or world-building details
+- Conflicts being introduced or resolved
+- Changes in a character's status, abilities, or position
+- Promises, agreements, or plans characters make
+- Deaths, departures, or arrivals
+- Significant emotional turning points that alter character dynamics
+- The opening or setup of a new scene, arc, or situation
+
+EXCLUDE only messages that are:
+- Redundant with another already-remembered summary (marked Long-term: Yes)
+- Purely transitional with no narrative content (e.g., just moving between locations without anything happening)
+- Minor reactions or internal thoughts that don't reveal anything new or change anything
+
+Below are the message summaries to analyze. Each line has this format: Message NUMBER | Long-term: Yes/No | Summary: TEXT
 
 {{summaries}}
 
-Your task: decide which of these messages should be preserved as long-term memories. A message is worth preserving if it introduces important characters, advances the plot, contains a key decision or revelation, or establishes facts the story depends on. Do NOT include messages that are routine actions, filler, minor reactions, or repeat information already covered by another remembered message.
-
-IMPORTANT: Be selective. Include messages that contain significant character development, major relationship changes, key decisions, important revelations, or events that later story developments depend on. Do not include routine conversations, minor emotional reactions, repeated information, or moments where nothing new is introduced. When in doubt, leave it out.
+When in doubt, preserve the memory. It is better to remember something that turns out minor than to forget something the story depends on later.
 
 Respond with ONLY the message numbers as a comma-separated list. Do not include any other text, explanation, or formatting. If no messages qualify, respond with the single word NONE.
 `

--- a/index.js
+++ b/index.js
@@ -3615,6 +3615,45 @@ async function remember_message_toggle(indexes=null, value=null) {
     }
     refresh_memory();
 }
+async function remember_auto_message_toggle(indexes=null, value=null) {
+    // Toggle the "remember_auto" (automated long-term memory) status of a set of messages.
+    // Messages already manually tagged with 'remember' are never touched.
+    let context = getContext();
+
+    if (!Array.isArray(indexes)) {
+        indexes = [indexes]
+    } else if (indexes === null) {
+        indexes = [Math.max(context.chat.length-1, 0)]
+    }
+
+    // Filter out any messages already manually marked as long-term
+    indexes = indexes.filter(i => !get_data(context.chat[i], 'remember'));
+
+    let summarize = [];
+
+    function set(index, val) {
+        let message = context.chat[index]
+        set_data(message, 'remember_auto', val);
+        set_data(message, 'exclude', false);
+
+        let memory = get_data(message, 'memory')
+        if (val && !memory) {
+            summarize.push(index)
+        }
+        debug(`Set message ${index} remember_auto status: ${val}`);
+    }
+
+    function check(index) {
+        return get_data(context.chat[index], 'remember_auto')
+    }
+
+    toggle_memory_value(indexes, value, check, set)
+
+    if (summarize.length > 0) {
+        await summaryQueue.summarize(summarize);
+    }
+    refresh_memory();
+}
 function collect_long_term_memory_summaries(scope, end_index) {
     // Collect all message summaries within the scope window, returned as parallel arrays of
     // formatted summary lines and their corresponding chat indexes.
@@ -3782,15 +3821,15 @@ async function automated_long_term_memory(scope_override=null, end_index=null) {
     let confirmed_set = new Set(all_confirmed);
 
     // Count only messages not already marked before toggling, so the toast reflects newly marked messages
-    let newly_marked_count = all_confirmed.filter(i => !get_data(chat[i], 'remember')).length;
-    await remember_message_toggle(all_confirmed, true);
+    let newly_marked_count = all_confirmed.filter(i => !get_data(chat[i], 'remember') && !get_data(chat[i], 'remember_auto')).length;
+    await remember_auto_message_toggle(all_confirmed, true);
 
     let removed_count = 0;
     if (get_settings('automated_memory_allow_removal')) {
-        let to_remove = valid_indexes.filter(i => !confirmed_set.has(i) && get_data(chat[i], 'remember'));
+        let to_remove = valid_indexes.filter(i => !confirmed_set.has(i) && get_data(chat[i], 'remember_auto'));
         if (to_remove.length > 0) {
             debug(`Automated LTM removing long-term flag from messages: ${to_remove.join(', ')}`);
-            await remember_message_toggle(to_remove, false);
+            await remember_auto_message_toggle(to_remove, false);
             removed_count = to_remove.length;
         }
     }

--- a/index.js
+++ b/index.js
@@ -133,12 +133,12 @@ const default_settings = {
     connection_profile: "",  // connection profile to use for summarization. Empty ("") indicates the same as currently selected.
 
     // automated long-term memory settings
-    automated_memory_scope: 'all',        // 'all' = all messages, 'new' = since last long-term memory, 'last_n' = last N messages
-    automated_memory_last_n: 50,          // number of messages to process when scope is 'last_n'
-    automated_memory_allow_removal: false, // whether the analysis can also un-mark existing long-term memories
-    automated_memory_importance: 'medium',  // importance threshold: none, high, medium, low
-    automated_memory_auto: false,                      // whether to automatically trigger LTM analysis every N messages
-    automated_memory_auto_interval: 25,               // how many new messages between automatic LTM runs (minimum 10)
+    automated_memory_scope: 'all',   // 'all' = all messages, 'new' = since last long-term memory, 'last_n' = last N messages
+    automated_memory_last_n: 50,   // number of messages to process when scope is 'last_n'
+    automated_memory_allow_removal: false,   // whether the analysis can also un-mark existing long-term memories
+    automated_memory_importance: 'medium',   // importance threshold: none, high, medium, low
+    automated_memory_auto: false,   // whether to automatically trigger LTM analysis every N messages
+    automated_memory_auto_interval: 25,   // how many new messages between automatic LTM runs (minimum 10)
 
     auto_summarize: true,   // whether to automatically summarize new chat messages
     summarization_delay: 0,  // delay auto-summarization by this many messages (0 summarizes immediately after sending, 1 waits for one message, etc)

--- a/index.js
+++ b/index.js
@@ -98,16 +98,10 @@ const default_automated_memory_prompt = `You are a narrative analysis assistant.
 
 Your task: decide which of these messages should be preserved as long-term memories. A message is worth preserving if it introduces important characters, advances the plot, contains a key decision or revelation, or establishes facts the story depends on. Do NOT include messages that are routine actions, filler, minor reactions, or repeat information already covered by another remembered message.
 
-{{importance}}
+nIMPORTANT: Be selective. Include messages that contain significant character development, major relationship changes, key decisions, important revelations, or events that later story developments depend on. Do not include routine conversations, minor emotional reactions, repeated information, or moments where nothing new is introduced. When in doubt, leave it out.
 
 Respond with ONLY the message numbers as a comma-separated list. Do not include any other text, explanation, or formatting. If no messages qualify, respond with the single word NONE.
 `
-const automated_memory_importance_prompts = {
-    none: '',
-    high: `\nIMPORTANT: Be very strict. Only select messages where ALL of the following are true: the message changes the direction of the story, the information cannot be found in any other message, and removing it would make the plot impossible to follow. Do not select routine character development, casual relationship moments, or incremental progress. When in doubt, leave it out.`,
-    medium: `\nIMPORTANT: Be selective. Include messages that contain significant character development, major relationship changes, key decisions, important revelations, or events that later story developments depend on. Do not include routine conversations, minor emotional reactions, repeated information, or moments where nothing new is introduced. When in doubt, leave it out.`,
-    low: `\nIMPORTANT: Be inclusive. Include any message that contains unique information, a meaningful character interaction, a noteworthy detail, or an event that adds to the story. Only exclude messages that are clearly trivial filler, simple greetings, or completely redundant with another already-remembered message. When in doubt, include it.`,
-}
 const default_long_template = `[Following is a list of events that occurred in the past]:\n{{${generic_memories_macro}}}\n`
 const default_short_template = `[Following is a list of recent events]:\n{{${generic_memories_macro}}}\n`
 const default_summary_macros = {  // default set of macros for the summary prompt.
@@ -136,7 +130,6 @@ const default_settings = {
     automated_memory_scope: 'all',   // 'all' = all messages, 'new' = since last long-term memory, 'last_n' = last N messages
     automated_memory_last_n: 50,   // number of messages to process when scope is 'last_n'
     automated_memory_allow_removal: false,   // whether the analysis can also un-mark existing long-term memories
-    automated_memory_importance: 'medium',   // importance threshold: none, high, medium, low
     automated_memory_auto: false,   // whether to automatically trigger LTM analysis every N messages
     automated_memory_auto_interval: 25,   // how many new messages between automatic LTM runs (minimum 10)
 
@@ -3665,12 +3658,11 @@ function collect_long_term_memory_summaries(scope, end_index) {
 
     return { summary_lines, valid_indexes };
 }
-async function analyze_long_term_memory_summary_chunk(chunk_lines, chunk_indexes, prompt_template, importance_text, profile) {
+async function analyze_long_term_memory_summary_chunk(chunk_lines, chunk_indexes, prompt_template, profile) {
     // Send a single chunk of summary lines to the LLM and return the confirmed chat indexes.
     // Returns null on failure.
     let prompt_text = prompt_template
-        .replace('{{summaries}}', chunk_lines.join('\n'))
-        .replace('{{importance}}', importance_text);
+        .replace('{{summaries}}', chunk_lines.join('\n'));
     let messages = [{role: 'system', content: prompt_text}];
 
     let result;
@@ -3748,7 +3740,6 @@ async function automated_long_term_memory(scope_override=null, end_index=null) {
 
     // Step 4: Process each chunk
     let prompt_template = get_settings('automated_memory_prompt');
-    let importance_text = automated_memory_importance_prompts[get_settings('automated_memory_importance') || 'none'] || '';
     let all_confirmed = [];
     let had_error = false;
 
@@ -3765,7 +3756,7 @@ async function automated_long_term_memory(scope_override=null, end_index=null) {
         }
 
         debug(`Running automated LTM analysis${use_chunking ? ` (batch ${c + 1}/${total_chunks})` : ''}...`);
-        let confirmed = await analyze_long_term_memory_summary_chunk(chunk.lines, chunk.indexes, prompt_template, importance_text, profile);
+        let confirmed = await analyze_long_term_memory_summary_chunk(chunk.lines, chunk.indexes, prompt_template, profile);
 
         if (confirmed === null) {
             had_error = true;
@@ -4476,7 +4467,6 @@ function initialize_settings_listeners() {
 <ul style="text-align: left; font-size: smaller;">
     <li>This prompt is sent to the LLM with all message summaries to identify critically important long-term memories.</li>
     <li><b>{{summaries}}</b> will be replaced with the formatted list of message summaries.</li>
-    <li><b>{{importance}}</b> will be replaced with the importance threshold guidance (based on the Importance Threshold setting).</li>
 </ul>`
         get_user_setting_text_input('automated_memory_prompt', t`Edit Automated Memory Prompt`, description)
     })
@@ -4554,7 +4544,6 @@ function initialize_settings_listeners() {
     bind_setting('input[name="automated_memory_scope"]', 'automated_memory_scope', 'text');
     bind_setting('#automated_memory_last_n', 'automated_memory_last_n', 'number');
     bind_setting('#automated_memory_allow_removal', 'automated_memory_allow_removal', 'boolean');
-    bind_setting('#automated_memory_importance', 'automated_memory_importance', 'text');
     bind_setting('#automated_memory_auto', 'automated_memory_auto', 'boolean');
     bind_setting('#automated_memory_auto_interval', 'automated_memory_auto_interval', 'number');
 

--- a/index.js
+++ b/index.js
@@ -49,6 +49,7 @@ const PROGRESS_BAR_ID = `${MODULE_NAME}_progress_bar`;
 const css_message_div = `qvink_memory_display`
 const css_short_memory = `qvink_short_memory`
 const css_long_memory = `qvink_long_memory`
+const css_long_auto_memory = `qvink_long_auto_memory`
 const css_remember_memory = `qvink_old_memory`
 const css_exclude_memory = `qvink_exclude_memory`
 const css_lagging_memory = `qvink_lagging_memory`
@@ -1424,13 +1425,17 @@ function get_message_div(index) {
 }
 function get_summary_style_class(message) {
     let include = get_data(message, 'include');
-    let remember = get_data(message, 'remember') || get_data(message, 'remember_auto');
+    let remember = get_data(message, 'remember');
+    let remember_auto = get_data(message, 'remember_auto');
     let exclude = get_data(message, 'exclude');  // force-excluded by user
     let lagging = get_data(message, 'lagging');  // not injected yet
 
     let style = ""
     if (remember && include) {  // marked to be remembered and included in memory anywhere
         style = css_long_memory
+    }
+    else if (remember_auto && include) {  // marked to be remembered automatically and included in memory anywhere
+        style = css_long_auto_memory
     } else if (include === "short") {  // not marked to remember, but included in short-term memory
         style = css_short_memory
     } else if (remember) {  // marked to be remembered but not included in memory

--- a/index.js
+++ b/index.js
@@ -4469,7 +4469,6 @@ function initialize_settings_listeners() {
 </ul>`
         get_user_setting_text_input('automated_memory_prompt', t`Edit Automated Memory Prompt`, description)
     })
-    bind_function('#process_all_ltm', () => automated_long_term_memory('all'));
     bind_function('#toggle_chat_memory', () => toggle_chat_enabled(), false);
     bind_function('#edit_memory_state', () => memoryEditInterface.show())
     bind_function("#refresh_memory", () => refresh_memory());

--- a/index.js
+++ b/index.js
@@ -3664,9 +3664,8 @@ async function remember_auto_message_toggle(indexes=null, value=null) {
     }
     refresh_memory();
 }
-function collect_long_term_memory_summaries(scope, end_index) {
-    // Collect all message summaries within the scope window, returned as parallel arrays of
-    // formatted summary lines and their corresponding chat indexes.
+function collect_ltm_scope_indexes(scope, end_index) {
+    // Return all chat indexes within the scope window (not filtered by whether they have a summary).
     let chat = getContext().chat;
     let last_index = end_index ?? chat.length - 1;
     let start_index = 0;
@@ -3694,17 +3693,23 @@ function collect_long_term_memory_summaries(scope, end_index) {
         }
     }
 
-    // Create a list of formatted summary lines and their corresponding indexes to pass to the LLM
+    let indexes = [];
+    for (let i = start_index; i <= last_index; i++) indexes.push(i);
+    return indexes;
+}
+function build_ltm_summary_lines(indexes) {
+    // Given a list of chat indexes, return formatted summary lines and the subset of indexes
+    // that actually have a summary, for passing to the LLM.
+    let chat = getContext().chat;
     let summary_lines = [];
     let valid_indexes = [];
-    for (let i = start_index; i <= last_index; i++) {
+    for (let i of indexes) {
         let memory = get_data(chat[i], 'memory');
         if (!memory) continue;
         let is_remembered = (get_data(chat[i], 'remember') || get_data(chat[i], 'remember_auto')) ? 'Yes' : 'No';
         summary_lines.push(`Message ${i} | Long-term: ${is_remembered} | Summary: ${memory}`);
         valid_indexes.push(i);
     }
-
     return { summary_lines, valid_indexes };
 }
 async function analyze_long_term_memory_summary_chunk(chunk_lines, chunk_indexes, prompt_template, profile) {
@@ -3738,15 +3743,16 @@ async function analyze_long_term_memory_summary_chunk(chunk_lines, chunk_indexes
     let chunk_valid_set = new Set(chunk_indexes);
     return parsed_numbers.filter(n => chunk_valid_set.has(n));
 }
-async function automated_long_term_memory(scope_override=null, end_index=null) {
+async function automated_long_term_memory(scope_override=null, end_index=null, indexes=null) {
     // Use an LLM to identify critically important summaries and mark them as long-term memories.
     // scope_override: if provided, ignores the scope setting ('all', 'new', 'last_n')
     // end_index: if provided, treat this as the latest message (inclusive) instead of the end of the chat
+    // indexes: if provided, analyse exactly these message indexes instead of deriving a scope window
     let chat = getContext().chat;
-    let scope = scope_override ?? get_settings('automated_memory_scope');
 
-    // Step 1: Collect summaries within the scope window
-    let { summary_lines, valid_indexes } = collect_long_term_memory_summaries(scope, end_index);
+    // Step 1: Collect summaries — either from explicit indexes or by deriving a scope window
+    let scope_indexes = indexes ?? collect_ltm_scope_indexes(scope_override ?? get_settings('automated_memory_scope'), end_index);
+    let { summary_lines, valid_indexes } = build_ltm_summary_lines(scope_indexes);
 
     if (summary_lines.length === 0) {
         log('No summaries found for automated long-term memory analysis.');

--- a/index.js
+++ b/index.js
@@ -69,9 +69,18 @@ const generic_memories_macro = `memories`;
 
 // message button classes
 const remember_button_class = `${MODULE_NAME}_remember_button`
+const automated_memory_auto_button_class = `${MODULE_NAME}_automated_memory_auto_button`
 const summarize_button_class = `${MODULE_NAME}_summarize_button`
 const edit_button_class = `${MODULE_NAME}_edit_button`
 const forget_button_class = `${MODULE_NAME}_forget_button`
+
+// global flags and whatnot
+var STOP_SUMMARIZATION = false  // flag toggled when stopping summarization
+var SUMMARIZATION_DELAY_TIMEOUT = null  // the set_timeout object for the summarization delay
+var SUMMARIZATION_DELAY_RESOLVE = null
+
+// Count new messages since last automated LTM run
+var automated_memory_auto_message_counter = 0
 
 // Settings
 const default_prompt = `You are a summarization assistant. Summarize the given fictional narrative in a single, very short and concise statement of fact.
@@ -88,6 +97,34 @@ Following is a history of messages for context:
 Following is the message to summarize:
 {{message}}
 `
+const default_detailed_prompt = `Summarize the following fictional message as a single paragraph of 2-3 sentences in past tense. Do not use bullet points or numbered lists.
+Include: character names (not pronouns), actions taken, dialogue points, emotional shifts, decisions made, and new information revealed.
+
+{{#if history}}
+Recent summary context (for reference only, do not re-summarize):
+{{history}}
+{{/if}}
+
+Message to summarize:
+{{message}}
+
+Summary:`
+const default_automated_memory_prompt = `You are a narrative analysis assistant. Below is a list of message summaries from a fictional roleplay. Each line has this format: Message NUMBER | Long-term: Yes/No | Summary: TEXT
+
+{{summaries}}
+
+Your task: decide which of these messages should be preserved as long-term memories. A message is worth preserving if it introduces important characters, advances the plot, contains a key decision or revelation, or establishes facts the story depends on. Do NOT include messages that are routine actions, filler, minor reactions, or repeat information already covered by another remembered message.
+
+{{importance}}
+
+Respond with ONLY the message numbers as a comma-separated list. Do not include any other text, explanation, or formatting. If no messages qualify, respond with the single word NONE.`
+
+const automated_memory_importance_prompts = {
+    none: '',
+    high: `\nIMPORTANT: Be very strict. Only select messages where ALL of the following are true: the message changes the direction of the story, the information cannot be found in any other message, and removing it would make the plot impossible to follow. Do not select routine character development, casual relationship moments, or incremental progress. When in doubt, leave it out.`,
+    medium: `\nIMPORTANT: Be selective. Include messages that contain significant character development, major relationship changes, key decisions, important revelations, or events that later story developments depend on. Do not include routine conversations, minor emotional reactions, repeated information, or moments where nothing new is introduced. When in doubt, leave it out.`,
+    low: `\nIMPORTANT: Be inclusive. Include any message that contains unique information, a meaningful character interaction, a noteworthy detail, or an event that adds to the story. Only exclude messages that are clearly trivial filler, simple greetings, or completely redundant with another already-remembered message. When in doubt, include it.`,
+}
 const default_long_template = `[Following is a list of events that occurred in the past]:\n{{${generic_memories_macro}}}\n`
 const default_short_template = `[Following is a list of recent events]:\n{{${generic_memories_macro}}}\n`
 const default_summary_macros = {  // default set of macros for the summary prompt.
@@ -105,11 +142,21 @@ const default_settings = {
 
     // summarization settings
     prompt: default_prompt,
+    detailed_prompt: default_detailed_prompt,
+    automated_memory_prompt: default_automated_memory_prompt,
     summary_prompt_macros: default_summary_macros,  // macros for the summary prompt interface
     prompt_role: extension_prompt_roles.SYSTEM,
     prefill: "",   // summary prompt prefill
     show_prefill: false, // whether to show the prefill when memories are displayed
     connection_profile: "",  // connection profile to use for summarization. Empty ("") indicates the same as currently selected.
+
+    // automated long-term memory settings
+    automated_memory_scope: 'all',        // 'all' = all messages, 'new' = since last long-term memory, 'last_n' = last N messages
+    automated_memory_last_n: 50,          // number of messages to process when scope is 'last_n'
+    automated_memory_allow_removal: false, // whether the analysis can also un-mark existing long-term memories
+    automated_memory_importance: 'medium',  // importance threshold: none, high, medium, low
+    automated_memory_auto: false,                      // whether to automatically trigger LTM analysis every N messages
+    automated_memory_auto_interval: 25,               // how many new messages between automatic LTM runs (minimum 10)
 
     auto_summarize: true,   // whether to automatically summarize new chat messages
     summarization_delay: 0,  // delay auto-summarization by this many messages (0 summarizes immediately after sending, 1 waits for one message, etc)
@@ -1025,6 +1072,13 @@ function refresh_settings() {
         get_settings_element('long_term_depth')?.parent().toggle(mid_chat)
         get_settings_element('long_term_role')?.parent().toggle(mid_chat)
 
+        // Disable the last_n input unless the last_n scope is selected
+        let scope = get_settings('automated_memory_scope');
+        get_settings_element('automated_memory_last_n')?.prop('disabled', scope !== 'last_n');
+
+        // Disable the interval input when auto LTM is off
+        let automated_memory_auto = get_settings('automated_memory_auto');
+        get_settings_element('automated_memory_auto_interval')?.prop('disabled', !automated_memory_auto);
 
     } else {  // memory is disabled for this chat
         $(`.${settings_content_class} .settings_input`).prop('disabled', true);  // disable all settings
@@ -1286,6 +1340,7 @@ async function delete_profile() {
         if (name === profile) {
             delete character_profiles[id]
         }
+        set_settings('character_profiles', character_profiles)
     }
     set_settings('character_profiles', character_profiles)
 
@@ -2279,7 +2334,11 @@ class SummaryPromptEditInterface {
             <h3>Summary Prompt</h3>
             <i class="fa-solid fa-info-circle" style="margin-right: 1em" title="Customize the prompt used for summarizing messages."></i>
             <button id="preview_summary_prompt" class="menu_button fa-solid fa-eye margin0" title="Preview current summary prompt (the exact text that will be sent to the model)"></button>
-            <button id="restore_default_prompt" class="menu_button fa-solid fa-recycle margin0 red_button" title="Restore the default prompt"></button>
+            <select id="restore_prompt_preset" class="text_pole inline_setting" title="Load a prompt preset">
+                <option value="" selected disabled>Load Preset</option>
+                <option value="default">Default</option>
+                <option value="detailed">Detailed</option>
+            </select>
 
             <label class="flex-container alignItemsCenter" title="Role used for the summary prompt" style="margin-left: auto;">
                 <span>Role: </span>
@@ -2444,7 +2503,7 @@ class SummaryPromptEditInterface {
         this.$content = $(this.popup.content)
         this.$buttons = this.$content.find('.popup-controls')
         this.$preview = this.$content.find('#preview_summary_prompt')
-        this.$restore = this.$content.find('#restore_default_prompt')
+        this.$restore = this.$content.find('#restore_prompt_preset')
         this.$definitions = this.$content.find('#macro_definitions')
         this.$add_macro = this.$content.find('#add_macro')
         this.$open_macros = this.$content.find('.open_macros')
@@ -2462,7 +2521,12 @@ class SummaryPromptEditInterface {
         // buttons
         this.$preview.on('click', () => this.preview_prompt())
         this.$add_macro.on('click', () => this.new_macro())
-        this.$restore.on('click', () => this.$prompt.val(default_settings["prompt"]))
+        this.$restore.on('change', (e) => {
+            const presets = { default: default_settings["prompt"], detailed: default_settings["detailed_prompt"] };
+            const selected = e.target.value;
+            if (presets[selected]) this.$prompt.val(presets[selected]);
+            e.target.value = '';  // reset to "Load Preset" placeholder
+        })
         this.$open_macros.on('click', () => {
             this.$content.find('.toggle-macro').toggle()
         })
@@ -3583,6 +3647,202 @@ async function remember_message_toggle(indexes=null, value=null) {
     }
     refresh_memory();
 }
+function collect_long_term_memory_summaries(scope, end_index) {
+    // Collect all message summaries within the scope window, returned as parallel arrays of
+    // formatted summary lines and their corresponding chat indexes.
+    let chat = getContext().chat;
+    let last_index = end_index ?? chat.length - 1;
+    let start_index = 0;
+
+    // Start from the most recent long-term memory (searching back from last_index)
+    if (scope === 'new') {
+        for (let i = last_index; i >= 0; i--) {
+            if (get_data(chat[i], 'remember')) {
+                start_index = i;
+                break;
+            }
+        }
+    // Count back N summarized messages from last_index
+    } else if (scope === 'last_n') {
+        let n = get_settings('automated_memory_last_n') || 50;
+        let count = 0;
+        for (let i = last_index; i >= 0; i--) {
+            if (get_data(chat[i], 'memory')) {
+                count++;
+                if (count >= n) {
+                    start_index = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    // Create a list of formatted summary lines and their corresponding indexes to pass to the LLM
+    let summary_lines = [];
+    let valid_indexes = [];
+    for (let i = start_index; i <= last_index; i++) {
+        let memory = get_data(chat[i], 'memory');
+        if (!memory) continue;
+        let is_remembered = get_data(chat[i], 'remember') ? 'Yes' : 'No';
+        summary_lines.push(`Message ${i} | Long-term: ${is_remembered} | Summary: ${memory}`);
+        valid_indexes.push(i);
+    }
+
+    return { summary_lines, valid_indexes };
+}
+async function analyze_long_term_memory_chunk(chunk_lines, chunk_indexes, prompt_template, importance_text) {
+    // Send a single chunk of summary lines to the LLM and return the confirmed chat indexes.
+    // Returns null on failure.
+    let prompt_text = prompt_template
+        .replace('{{summaries}}', chunk_lines.join('\n'))
+        .replace('{{importance}}', importance_text);
+    let messages = [{role: 'system', content: prompt_text}];
+
+    let result;
+    try {
+        result = await summarize_text(messages);
+    } catch (e) {
+        error(`Automated LTM chunk analysis failed: ${e.message || e}`);
+        return null;
+    }
+
+    if (!result) {
+        error('Automated LTM chunk analysis returned no result.');
+        return null;
+    }
+
+    debug(`Automated LTM chunk response: ${result}`);
+
+    if (result.trim().toUpperCase() === 'NONE') {
+        return [];
+    }
+
+    let parsed_numbers = result.match(/\d+/g)?.map(Number) || [];
+    let chunk_valid_set = new Set(chunk_indexes);
+    return parsed_numbers.filter(n => chunk_valid_set.has(n));
+}
+async function automated_long_term_memory(scope_override=null, end_index=null) {
+    // Use an LLM to identify critically important summaries and mark them as long-term memories.
+    // scope_override: if provided, ignores the scope setting ('all', 'new', 'last_n')
+    // end_index: if provided, treat this as the latest message (inclusive) instead of the end of the chat
+    let chat = getContext().chat;
+    let scope = scope_override ?? get_settings('automated_memory_scope');
+
+    // Step 1: Collect summaries within the scope window
+    let { summary_lines, valid_indexes } = collect_long_term_memory_summaries(scope, end_index);
+
+    if (summary_lines.length === 0) {
+        log('No summaries found for automated long-term memory analysis.');
+        toastr.warning('No summarized messages found to analyze.', MODULE_NAME_FANCY);
+        return;
+    }
+
+    // Step 2: Determine chunking — when processing all with a non-'all' scope, split into chunks of last_n.
+    // 'all' scope sends everything in a single batch; 'new' and 'last_n' chunk by last_n size.
+    let chunk_size = get_settings('automated_memory_last_n') || 50;
+    let is_process_all = scope_override === 'all';
+    let scope_allows_chunking = get_settings('automated_memory_scope') !== 'all';
+    let exceeds_chunk_size = summary_lines.length > chunk_size;
+    let use_chunking = is_process_all && scope_allows_chunking && exceeds_chunk_size;
+    let chunks = [];
+    if (use_chunking) {
+        for (let i = 0; i < summary_lines.length; i += chunk_size) {
+            chunks.push({
+                lines: summary_lines.slice(i, i + chunk_size),
+                indexes: valid_indexes.slice(i, i + chunk_size),
+            });
+        }
+        debug(`Processing ${summary_lines.length} summaries in ${chunks.length} chunks of up to ${chunk_size}`);
+    } else {
+        chunks.push({ lines: summary_lines, indexes: valid_indexes });
+    }
+
+    // Show a persistent blue notification while the LLM is working
+    let total_chunks = chunks.length;
+    let $progress_toast = toastr.info(
+        use_chunking
+            ? `Analyzing ${summary_lines.length} summaries in ${total_chunks} batches...`
+            : `Analyzing ${summary_lines.length} message summaries...`,
+        MODULE_NAME_FANCY,
+        { timeOut: 0, extendedTimeOut: 0, tapToDismiss: false }
+    );
+
+    // Step 3: Switch to summary preset/profile
+    let summary_preset = get_settings('completion_preset');
+    let current_preset = await get_current_preset();
+    let summary_profile = get_settings('connection_profile');
+    let current_profile = await get_current_connection_profile();
+
+    await set_connection_profile(summary_profile);
+    await set_preset(summary_preset);
+
+    // Step 4: Process each chunk
+    let prompt_template = get_settings('automated_memory_prompt');
+    let importance_text = automated_memory_importance_prompts[get_settings('automated_memory_importance') || 'none'] || '';
+    let all_confirmed = [];
+    let had_error = false;
+
+    for (let c = 0; c < chunks.length; c++) {
+        let chunk = chunks[c];
+
+        if (use_chunking) {
+            toastr.clear($progress_toast);
+            $progress_toast = toastr.info(
+                `Processing batch ${c + 1} of ${total_chunks} (${chunk.lines.length} messages)...`,
+                MODULE_NAME_FANCY,
+                { timeOut: 0, extendedTimeOut: 0, tapToDismiss: false }
+            );
+        }
+
+        debug(`Running automated LTM analysis${use_chunking ? ` (batch ${c + 1}/${total_chunks})` : ''}...`);
+        let confirmed = await analyze_long_term_memory_chunk(chunk.lines, chunk.indexes, prompt_template, importance_text);
+
+        if (confirmed === null) {
+            had_error = true;
+            break;
+        }
+
+        all_confirmed.push(...confirmed);
+    }
+
+    // Restore preset/profile
+    await set_connection_profile(current_profile);
+    await set_preset(current_preset);
+
+    toastr.clear($progress_toast);
+
+    if (had_error) return;
+
+    if (all_confirmed.length === 0) {
+        log('Automated long-term memory analysis: no critically important messages identified.');
+        toastr.info('Analysis complete — no messages were identified as critically important.', MODULE_NAME_FANCY);
+        return;
+    }
+
+    debug(`Automated LTM marking messages as long-term: ${all_confirmed.join(', ')}`);
+
+    // Step 5: Mark confirmed messages as long-term, and optionally remove the flag from others
+    let confirmed_set = new Set(all_confirmed);
+
+    // Count only messages not already marked before toggling, so the toast reflects newly marked messages
+    let newly_marked_count = all_confirmed.filter(i => !get_data(chat[i], 'remember')).length;
+    await remember_message_toggle(all_confirmed, true);
+
+    let removed_count = 0;
+    if (get_settings('automated_memory_allow_removal')) {
+        let to_remove = valid_indexes.filter(i => !confirmed_set.has(i) && get_data(chat[i], 'remember'));
+        if (to_remove.length > 0) {
+            debug(`Automated LTM removing long-term flag from messages: ${to_remove.join(', ')}`);
+            await remember_message_toggle(to_remove, false);
+            removed_count = to_remove.length;
+        }
+    }
+
+    let summary_msg = `Long-term memory updated — ${newly_marked_count} message${newly_marked_count !== 1 ? 's' : ''} newly marked as important.`;
+    if (removed_count > 0) summary_msg += ` ${removed_count} removed.`;
+    toastr.success(summary_msg, MODULE_NAME_FANCY);
+    log(summary_msg);
+}
 function forget_message_toggle(indexes=null, value=null) {
     // Toggle the "forget" status of a message
     let context = getContext();
@@ -4052,6 +4312,21 @@ async function auto_summarize_chat(skip_initial_delay=true) {
     await summaryQueue.summarize(messages_to_summarize, skip_initial_delay, show_progress);
 }
 
+async function check_automated_memory_auto_trigger() {
+    // Increment the message counter and fire automated_long_term_memory if the interval has been reached
+    if (!get_settings('automated_memory_auto') || !chat_enabled()) return;
+
+    automated_memory_auto_message_counter++;
+    let interval = Math.max(10, get_settings('automated_memory_auto_interval') || 25);
+    debug(`Auto LTM counter: ${automated_memory_auto_message_counter} / ${interval}`);
+
+    if (automated_memory_auto_message_counter >= interval) {
+        automated_memory_auto_message_counter = 0;
+        log('Auto LTM interval reached, running automated long-term memory analysis...');
+        await automated_long_term_memory();
+    }
+}
+
 // Event handling
 var last_message_swiped = null;  // if an index, that was the last message swiped
 var last_message = null; // if an index, that was the last message sent
@@ -4077,6 +4352,7 @@ async function on_chat_event(event=null, data=null) {
 
 
             reset_injection_threshold()
+            automated_memory_auto_message_counter = 0;  // reset counter on chat change
             auto_load_profile();  // load the profile for the current chat or character
             refresh_memory();  // refresh the memory state
             if (context?.chat?.length) {
@@ -4117,6 +4393,12 @@ async function on_chat_event(event=null, data=null) {
             last_message_swiped = null;
             last_message = null;
             if (!chat_enabled()) break;  // if chat is disabled, do nothing
+
+            // Count user messages toward auto LTM if user messages are included in summarization
+            if (get_settings('include_user_messages')) {
+                await check_automated_memory_auto_trigger();
+            }
+
             if (!get_settings('auto_summarize')) break;  // if auto-summarize is disabled, do nothing
             if (just_opened) break;  // don't auto-summarize if just opened the chat
 
@@ -4153,6 +4435,7 @@ async function on_chat_event(event=null, data=null) {
                 refresh_memory()
             } else { // not a swipe or continue
                 last_message_swiped = null
+                await check_automated_memory_auto_trigger();  // count new char message toward auto LTM
                 if (!get_settings('auto_summarize')) break;  // if auto-summarize is disabled, do nothing
                 if (get_settings("auto_summarize_on_send")) break;  // if auto_summarize_on_send is enabled, don't auto-summarize on character message
                 debug("New message detected, summarizing")
@@ -4222,6 +4505,16 @@ function initialize_settings_listeners() {
     bind_function('#stop_summarization', () => summaryQueue.stop());
     bind_function('#revert_settings', reset_settings);
 
+    bind_function('#edit_automated_memory_prompt', async () => {
+        let description = `
+<ul style="text-align: left; font-size: smaller;">
+    <li>This prompt is sent to the LLM with all message summaries to identify critically important long-term memories.</li>
+    <li><b>{{summaries}}</b> will be replaced with the formatted list of message summaries.</li>
+    <li><b>{{importance}}</b> will be replaced with the importance threshold guidance (based on the Importance Threshold setting).</li>
+</ul>`
+        get_user_setting_text_input('automated_memory_prompt', t`Edit Automated Memory Prompt`, description)
+    })
+    bind_function('#process_all_ltm', () => automated_long_term_memory('all'));
     bind_function('#toggle_chat_memory', () => toggle_chat_enabled(), false);
     bind_function('#edit_memory_state', () => memoryEditInterface.show())
     bind_function("#refresh_memory", () => refresh_memory());
@@ -4292,6 +4585,13 @@ function initialize_settings_listeners() {
     bind_setting('#long_term_context_limit', 'long_term_context_limit', 'number')
     bind_setting('#long_term_context_type', 'long_term_context_type', 'text')
 
+    bind_setting('input[name="automated_memory_scope"]', 'automated_memory_scope', 'text');
+    bind_setting('#automated_memory_last_n', 'automated_memory_last_n', 'number');
+    bind_setting('#automated_memory_allow_removal', 'automated_memory_allow_removal', 'boolean');
+    bind_setting('#automated_memory_importance', 'automated_memory_importance', 'text');
+    bind_setting('#automated_memory_auto', 'automated_memory_auto', 'boolean');
+    bind_setting('#automated_memory_auto_interval', 'automated_memory_auto_interval', 'number');
+
     bind_setting('#debug_mode', 'debug_mode', 'boolean');
     bind_setting('#display_memories', 'display_memories', 'boolean')
     bind_setting('#default_chat_enabled', 'default_chat_enabled', 'boolean');
@@ -4309,6 +4609,7 @@ function initialize_message_buttons() {
     let ctx = getContext()
 
     let html = `
+<div title="${t`Process Long-Term Memory (analyze all summaries and automatically tag critically important messages for long-term memory)`}" class="mes_button ${automated_memory_auto_button_class} fa-solid fa-cloud-bolt" tabindex="0"></div>
 <div title="${t`Remember (toggle inclusion of summary in long-term memory)`}" class="mes_button ${remember_button_class} fa-solid fa-brain" tabindex="0"></div>
 <div title="${t`Force Exclude (toggle inclusion of summary from all memory)`}" class="mes_button ${forget_button_class} fa-solid fa-ban" tabindex="0"></div>
 <div title="${t`Edit Summary`}" class="mes_button ${edit_button_class} fa-solid fa-pen-fancy" tabindex="0"></div>
@@ -4320,6 +4621,11 @@ function initialize_message_buttons() {
 
     // button events
     let $chat = $("div#chat")
+    $chat.on("click", `.${automated_memory_auto_button_class}`, async function () {
+        const message_block = $(this).closest(".mes");
+        const message_id = Number(message_block.attr("mesid"));
+        await automated_long_term_memory(null, message_id);
+    });
     $chat.on("click", `.${remember_button_class}`, async function () {
         const message_block = $(this).closest(".mes");
         const message_id = Number(message_block.attr("mesid"));

--- a/index.js
+++ b/index.js
@@ -100,8 +100,8 @@ Your task: decide which of these messages should be preserved as long-term memor
 
 {{importance}}
 
-Respond with ONLY the message numbers as a comma-separated list. Do not include any other text, explanation, or formatting. If no messages qualify, respond with the single word NONE.`
-
+Respond with ONLY the message numbers as a comma-separated list. Do not include any other text, explanation, or formatting. If no messages qualify, respond with the single word NONE.
+`
 const automated_memory_importance_prompts = {
     none: '',
     high: `\nIMPORTANT: Be very strict. Only select messages where ALL of the following are true: the message changes the direction of the story, the information cannot be found in any other message, and removing it would make the plot impossible to follow. Do not select routine character development, casual relationship moments, or incremental progress. When in doubt, leave it out.`,

--- a/index.js
+++ b/index.js
@@ -69,15 +69,10 @@ const generic_memories_macro = `memories`;
 
 // message button classes
 const remember_button_class = `${MODULE_NAME}_remember_button`
-const automated_memory_auto_button_class = `${MODULE_NAME}_automated_memory_auto_button`
 const summarize_button_class = `${MODULE_NAME}_summarize_button`
 const edit_button_class = `${MODULE_NAME}_edit_button`
 const forget_button_class = `${MODULE_NAME}_forget_button`
-
-// global flags and whatnot
-var STOP_SUMMARIZATION = false  // flag toggled when stopping summarization
-var SUMMARIZATION_DELAY_TIMEOUT = null  // the set_timeout object for the summarization delay
-var SUMMARIZATION_DELAY_RESOLVE = null
+const automated_memory_auto_button_class = `${MODULE_NAME}_automated_memory_auto_button`
 
 // Count new messages since last automated LTM run
 var automated_memory_auto_message_counter = 0
@@ -3690,7 +3685,7 @@ function collect_long_term_memory_summaries(scope, end_index) {
 
     return { summary_lines, valid_indexes };
 }
-async function analyze_long_term_memory_chunk(chunk_lines, chunk_indexes, prompt_template, importance_text) {
+async function analyze_long_term_memory_chunk(chunk_lines, chunk_indexes, prompt_template, importance_text, profile) {
     // Send a single chunk of summary lines to the LLM and return the confirmed chat indexes.
     // Returns null on failure.
     let prompt_text = prompt_template
@@ -3700,7 +3695,7 @@ async function analyze_long_term_memory_chunk(chunk_lines, chunk_indexes, prompt
 
     let result;
     try {
-        result = await summarize_text(messages);
+        result = await summarize_text(messages, profile);
     } catch (e) {
         error(`Automated LTM chunk analysis failed: ${e.message || e}`);
         return null;
@@ -3711,13 +3706,14 @@ async function analyze_long_term_memory_chunk(chunk_lines, chunk_indexes, prompt
         return null;
     }
 
-    debug(`Automated LTM chunk response: ${result}`);
+    let content = result.content;
+    debug(`Automated LTM chunk response: ${content}`);
 
-    if (result.trim().toUpperCase() === 'NONE') {
+    if (content.trim().toUpperCase() === 'NONE') {
         return [];
     }
 
-    let parsed_numbers = result.match(/\d+/g)?.map(Number) || [];
+    let parsed_numbers = content.match(/\d+/g)?.map(Number) || [];
     let chunk_valid_set = new Set(chunk_indexes);
     return parsed_numbers.filter(n => chunk_valid_set.has(n));
 }
@@ -3767,14 +3763,8 @@ async function automated_long_term_memory(scope_override=null, end_index=null) {
         { timeOut: 0, extendedTimeOut: 0, tapToDismiss: false }
     );
 
-    // Step 3: Switch to summary preset/profile
-    let summary_preset = get_settings('completion_preset');
-    let current_preset = await get_current_preset();
-    let summary_profile = get_settings('connection_profile');
-    let current_profile = await get_current_connection_profile();
-
-    await set_connection_profile(summary_profile);
-    await set_preset(summary_preset);
+    // Step 3: Resolve the connection profile to use for LTM analysis
+    let profile = get_summary_connection_profile();
 
     // Step 4: Process each chunk
     let prompt_template = get_settings('automated_memory_prompt');
@@ -3795,7 +3785,7 @@ async function automated_long_term_memory(scope_override=null, end_index=null) {
         }
 
         debug(`Running automated LTM analysis${use_chunking ? ` (batch ${c + 1}/${total_chunks})` : ''}...`);
-        let confirmed = await analyze_long_term_memory_chunk(chunk.lines, chunk.indexes, prompt_template, importance_text);
+        let confirmed = await analyze_long_term_memory_chunk(chunk.lines, chunk.indexes, prompt_template, importance_text, profile);
 
         if (confirmed === null) {
             had_error = true;
@@ -3804,10 +3794,6 @@ async function automated_long_term_memory(scope_override=null, end_index=null) {
 
         all_confirmed.push(...confirmed);
     }
-
-    // Restore preset/profile
-    await set_connection_profile(current_profile);
-    await set_preset(current_preset);
 
     toastr.clear($progress_toast);
 

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ const default_automated_memory_prompt = `You are a narrative analysis assistant.
 
 Your task: decide which of these messages should be preserved as long-term memories. A message is worth preserving if it introduces important characters, advances the plot, contains a key decision or revelation, or establishes facts the story depends on. Do NOT include messages that are routine actions, filler, minor reactions, or repeat information already covered by another remembered message.
 
-nIMPORTANT: Be selective. Include messages that contain significant character development, major relationship changes, key decisions, important revelations, or events that later story developments depend on. Do not include routine conversations, minor emotional reactions, repeated information, or moments where nothing new is introduced. When in doubt, leave it out.
+IMPORTANT: Be selective. Include messages that contain significant character development, major relationship changes, key decisions, important revelations, or events that later story developments depend on. Do not include routine conversations, minor emotional reactions, repeated information, or moments where nothing new is introduced. When in doubt, leave it out.
 
 Respond with ONLY the message numbers as a comma-separated list. Do not include any other text, explanation, or formatting. If no messages qualify, respond with the single word NONE.
 `

--- a/index.js
+++ b/index.js
@@ -93,33 +93,33 @@ Following is a history of messages for context:
 Following is the message to summarize:
 {{message}}
 `
-const default_automated_memory_prompt = `You are a narrative analysis assistant for an ongoing fictional roleplay. Your task: decide which message summaries should be preserved as long-term memories. This is an ongoing story — you cannot know for certain what will matter later, so err on the side of preserving anything that could be referenced or built upon.
+const default_automated_memory_prompt = `You are a narrative analysis assistant for an ongoing fictional roleplay. Your task: decide which message summaries should be preserved as long-term memories.
 
-PRESERVE messages that contain any of the following:
-- A new character appearing or being introduced
-- Characters meeting or interacting for the first time
+The key test for each summary: does it introduce a fact, name, relationship detail, backstory, or situation change that would be LOST if this summary were removed? If removing it would leave no gap in the story's record, it is not worth preserving.
+
+PRESERVE messages that introduce new information such as:
+- A character's name, identity, or backstory being revealed
+- New facts about a character's situation, history, or motivations
 - Relationship developments (friendships, conflicts, romance, alliances, betrayals, trust shifts)
-- Plot-advancing events or actions that change the story's direction
+- Events that change the characters' situation or the story's direction
 - Key decisions or commitments made by characters
-- Revelations, discoveries, or new information about characters or the world
-- New locations, setting changes, or world-building details
+- New locations, setting details, or world-building facts
 - Conflicts being introduced or resolved
 - Changes in a character's status, abilities, or position
 - Promises, agreements, or plans characters make
 - Deaths, departures, or arrivals
-- Significant emotional turning points that alter character dynamics
-- The opening or setup of a new scene, arc, or situation
 
-EXCLUDE only messages that are:
+EXCLUDE messages that are:
+- Conversational scaffolding — questions, comments, small talk, or reactions that don't themselves contain new facts (even if they prompt a reveal in the next message)
 - Redundant with another already-remembered summary (marked Long-term: Yes)
-- Purely transitional with no narrative content (e.g., just moving between locations without anything happening)
-- Minor reactions or internal thoughts that don't reveal anything new or change anything
+- Purely transitional actions with no new narrative content
+- Minor reactions or internal thoughts that don't reveal anything new
+
+This is an ongoing story — you cannot know for certain what will matter later. When a summary contains new information, preserve it even if it seems minor now.
 
 Below are the message summaries to analyze. Each line has this format: Message NUMBER | Long-term: Yes/No | Summary: TEXT
 
 {{summaries}}
-
-When in doubt, preserve the memory. It is better to remember something that turns out minor than to forget something the story depends on later.
 
 Respond with ONLY the message numbers as a comma-separated list. Do not include any other text, explanation, or formatting. If no messages qualify, respond with the single word NONE.
 `

--- a/index.js
+++ b/index.js
@@ -3455,10 +3455,29 @@ class SummaryQueue {
         }
 
         let connection = ctx.ConnectionManagerRequestService.getProfile(profile);
-        console.warn('connection properties:', connection);
         if (!connection) {
             throw new Error(`No connection found for profile: ${profile}`);
         }
+        console.warn('[summarize_text] connection profile:', connection);
+        console.warn('[summarize_text] overridePayload fields (from profile):', {
+            custom_url: connection['api-url'],
+            vertexai_region: connection['api-url'],
+            zai_endpoint: connection['api-url'],
+            siliconflow_endpoint: connection['api-url'],
+            model: connection.model,
+            preset: connection.preset,
+            proxy: connection.proxy,
+        });
+        console.warn('[summarize_text] chatCompletionSettings (relevant fields):', {
+            chat_completion_source: ctx.chatCompletionSettings?.chat_completion_source,
+            custom_url: ctx.chatCompletionSettings?.custom_url,
+            custom_include_body: ctx.chatCompletionSettings?.custom_include_body,
+            custom_exclude_body: ctx.chatCompletionSettings?.custom_exclude_body,
+            custom_include_headers: ctx.chatCompletionSettings?.custom_include_headers,
+            vertexai_region: ctx.chatCompletionSettings?.vertexai_region,
+            zai_endpoint: ctx.chatCompletionSettings?.zai_endpoint,
+            siliconflow_endpoint: ctx.chatCompletionSettings?.siliconflow_endpoint,
+        });
 
         let result = await ctx.ConnectionManagerRequestService.sendRequest(profile, messages)
 

--- a/index.js
+++ b/index.js
@@ -3474,9 +3474,14 @@ class SummaryQueue {
             custom_include_body: ctx.chatCompletionSettings?.custom_include_body,
             custom_exclude_body: ctx.chatCompletionSettings?.custom_exclude_body,
             custom_include_headers: ctx.chatCompletionSettings?.custom_include_headers,
-            vertexai_region: ctx.chatCompletionSettings?.vertexai_region,
-            zai_endpoint: ctx.chatCompletionSettings?.zai_endpoint,
-            siliconflow_endpoint: ctx.chatCompletionSettings?.siliconflow_endpoint,
+        });
+
+        const presetManager = ctx.getPresetManager?.('openai');
+        const preset = presetManager?.getCompletionPresetByName?.(connection.preset);
+        console.warn('[summarize_text] preset fields (chat_completion_source may override settings):', {
+            name: preset?.name,
+            chat_completion_source: preset?.chat_completion_source,
+            temperature: preset?.temperature,
         });
 
         let result = await ctx.ConnectionManagerRequestService.sendRequest(profile, messages)

--- a/index.js
+++ b/index.js
@@ -1785,6 +1785,7 @@ class MemoryEditInterface {
     <div><button id="bulk_exclude"    class="menu_button" title="Toggle inclusion of selected summaries from all memory">     <i class="fa-solid fa-ban"></i>Exclude</button></div>
     <div><button id="bulk_copy"       class="menu_button" title="Copy selected memories to clipboard">                        <i class="fa-solid fa-copy"></i>Copy</button></div>
     <div><button id="bulk_summarize"  class="menu_button" title="Re-Summarize selected memories">                             <i class="fa-solid fa-quote-left"></i>Summarize</button></div>
+    <div><button id="bulk_auto_ltm"   class="menu_button" title="Run automated long-term memory analysis on selected memories"><i class="fa-solid fa-wand-magic-sparkles"></i>Auto Long-Term</button></div>
     <div><button id="bulk_delete"     class="menu_button" title="Delete selected memories">                                   <i class="fa-solid fa-trash"></i>Delete</button></div>
     <div><button id="bulk_regex"      class="menu_button" title="Run the selected regex script on selected memories">         <i class="fa-solid fa-shuffle"></i>Regex Replace</button></div>
     <div><select id="regex_selector"  title="Choose regex script"></select>
@@ -1900,6 +1901,10 @@ class MemoryEditInterface {
         })
         this.$content.find(`#bulk_summarize`).on('click', async () => {
             await summaryQueue.summarize(this.get_sorted_selection());  // summarize in ascending order
+        })
+        this.$content.find(`#bulk_auto_ltm`).on('click', async () => {
+            await automated_long_term_memory(null, null, this.get_sorted_selection());
+            this.update_table();
         })
         this.$content.find(`#bulk_delete`).on('click', () => {
             this.get_sorted_selection().forEach(id => {

--- a/index.js
+++ b/index.js
@@ -1891,14 +1891,7 @@ class MemoryEditInterface {
 
         // bulk action buttons
         this.$content.find(`#bulk_remember`).on('click', () => {
-            let selection = this.get_sorted_selection();
-            // Get nessages that are manual and not auto and toggle them normally with remember_message_toggle
-            let manual_remember = selection.filter(i => !get_data(this.ctx.chat[i], 'remember_auto') || get_data(this.ctx.chat[i], 'remember'));
-            if (manual_remember.length > 0) remember_message_toggle(manual_remember);
-
-            // For auto-only messages we can only toggle them to "false"
-            let auto_only = selection.filter(i => get_data(this.ctx.chat[i], 'remember_auto') && !get_data(this.ctx.chat[i], 'remember'));
-            if (auto_only.length > 0) remember_auto_message_toggle(auto_only, false);
+            remember_message_toggle(this.get_sorted_selection())
             this.update_table()
         })
         this.$content.find(`#bulk_exclude`).on('click', () => {
@@ -1938,11 +1931,7 @@ class MemoryEditInterface {
         })
         this.$content.on("click", `tr .${remember_button_class}`, function () {
             let message_id = Number($(this).closest('tr').attr('message_id'));  // get the message ID from the row's "message_id" attribute
-            if (get_data(self.ctx.chat[message_id], 'remember_auto')) {
-                remember_auto_message_toggle(message_id, false);
-            } else {
-                remember_message_toggle(message_id);
-            }
+            remember_message_toggle(message_id);
             self.update_table()
         });
         this.$content.on("click", `tr .${forget_button_class}`, function () {
@@ -3615,7 +3604,7 @@ async function remember_message_toggle(indexes=null, value=null) {
         let message = context.chat[index]
         set_data(message, 'remember', value);
         set_data(message, 'exclude', false);  // regardless, remove excluded flag
-        if (!value) set_data(message, 'remember_auto', false);  // clearing remember also clears auto
+        set_data(message, 'remember_auto', false);  // always clear auto flag when manually toggling
 
         let memory = get_data(message, 'memory')
         if (value && !memory) {

--- a/index.js
+++ b/index.js
@@ -3454,7 +3454,7 @@ class SummaryQueue {
             error(`Text to summarize (${token_size}) exceeds summary context size (${context_size}).`);
         }
 
-        let connection = ctx.ConnectionManagerRequestService.getConnection(profile);
+        let connection = ctx.ConnectionManagerRequestService.getProfile(profile);
         console.warn('connection properties:', connection);
         if (!connection) {
             throw new Error(`No connection found for profile: ${profile}`);

--- a/index.js
+++ b/index.js
@@ -120,6 +120,7 @@ EXCLUDE messages that are:
 This is an ongoing story — you cannot know for certain what will matter later. When a summary contains new information, preserve it even if it seems minor now.
 
 Below are the message summaries to analyze. Each line has this format: Message NUMBER | Long-term: Yes/No | Summary: TEXT
+Messages already marked "Long-term: Yes" are examples of the kind of summary worth preserving — use them as a reference for the quality and relevance bar when evaluating unmarked messages.
 
 {{summaries}}
 

--- a/index.js
+++ b/index.js
@@ -3717,37 +3717,6 @@ function build_ltm_summary_lines(indexes) {
     }
     return { summary_lines, valid_indexes };
 }
-async function analyze_long_term_memory_summary_chunk(chunk_lines, chunk_indexes, prompt_template, profile) {
-    // Send a single chunk of summary lines to the LLM and return the confirmed chat indexes.
-    // Returns null on failure.
-    let prompt_text = prompt_template
-        .replace('{{summaries}}', chunk_lines.join('\n'));
-    let messages = [{role: 'system', content: prompt_text}];
-
-    let result;
-    try {
-        result = await summaryQueue.summarize_text(messages, profile);
-    } catch (e) {
-        error(`Automated LTM chunk analysis failed: ${e.message || e}`);
-        return null;
-    }
-
-    if (!result) {
-        error('Automated LTM chunk analysis returned no result.');
-        return null;
-    }
-
-    let content = result.content;
-    debug(`Automated LTM chunk response: ${content}`);
-
-    if (content.trim().toUpperCase() === 'NONE') {
-        return [];
-    }
-
-    let parsed_numbers = content.match(/\d+/g)?.map(Number) || [];
-    let chunk_valid_set = new Set(chunk_indexes);
-    return parsed_numbers.filter(n => chunk_valid_set.has(n));
-}
 async function automated_long_term_memory(scope_override=null, end_index=null, indexes=null) {
     // Use an LLM to identify critically important summaries and mark them as long-term memories.
     // scope_override: if provided, ignores the scope setting ('all', 'new', 'last_n')
@@ -3765,70 +3734,40 @@ async function automated_long_term_memory(scope_override=null, end_index=null, i
         return;
     }
 
-    // Step 2: Determine chunking — when processing all with a non-'all' scope, split into chunks of last_n.
-    // 'all' scope sends everything in a single batch; 'new' and 'last_n' chunk by last_n size.
-    let chunk_size = get_settings('automated_memory_last_n') || 50;
-    let is_process_all = scope_override === 'all';
-    let scope_allows_chunking = get_settings('automated_memory_scope') !== 'all';
-    let exceeds_chunk_size = summary_lines.length > chunk_size;
-    let use_chunking = is_process_all && scope_allows_chunking && exceeds_chunk_size;
-    let chunks = [];
-    if (use_chunking) {
-        for (let i = 0; i < summary_lines.length; i += chunk_size) {
-            chunks.push({
-                lines: summary_lines.slice(i, i + chunk_size),
-                indexes: valid_indexes.slice(i, i + chunk_size),
-            });
-        }
-        debug(`Processing ${summary_lines.length} summaries in ${chunks.length} chunks of up to ${chunk_size}`);
-    } else {
-        chunks.push({ lines: summary_lines, indexes: valid_indexes });
-    }
-
-    // Show a persistent blue notification while the LLM is working
-    let total_chunks = chunks.length;
-    let $progress_toast = toastr.info(
-        use_chunking
-            ? `Analyzing ${summary_lines.length} summaries in ${total_chunks} batches...`
-            : `Analyzing ${summary_lines.length} message summaries...`,
-        MODULE_NAME_FANCY,
-        { timeOut: 0, extendedTimeOut: 0, tapToDismiss: false }
-    );
-
-    // Step 3: Resolve the connection profile to use for LTM analysis
+    // Step 2: Send summaries to the LLM for analysis
+    let prompt_text = get_settings('automated_memory_prompt').replace('{{summaries}}', summary_lines.join('\n'));
+    let messages = [{role: 'system', content: prompt_text}];
     let profile = get_summary_connection_profile();
 
-    // Step 4: Process each chunk
-    let prompt_template = get_settings('automated_memory_prompt');
-    let all_confirmed = [];
-    let had_error = false;
-
-    for (let c = 0; c < chunks.length; c++) {
-        let chunk = chunks[c];
-
-        if (use_chunking) {
-            toastr.clear($progress_toast);
-            $progress_toast = toastr.info(
-                `Processing batch ${c + 1} of ${total_chunks} (${chunk.lines.length} messages)...`,
-                MODULE_NAME_FANCY,
-                { timeOut: 0, extendedTimeOut: 0, tapToDismiss: false }
-            );
-        }
-
-        debug(`Running automated LTM analysis${use_chunking ? ` (batch ${c + 1}/${total_chunks})` : ''}...`);
-        let confirmed = await analyze_long_term_memory_summary_chunk(chunk.lines, chunk.indexes, prompt_template, profile);
-
-        if (confirmed === null) {
-            had_error = true;
-            break;
-        }
-
-        all_confirmed.push(...confirmed);
+    let $progress_toast = toastr.info(`Analyzing ${summary_lines.length} message summaries...`, MODULE_NAME_FANCY, { timeOut: 0, extendedTimeOut: 0, tapToDismiss: false });
+    debug('Running automated LTM analysis...');
+    let result;
+    try {
+        result = await summaryQueue.summarize_text(messages, profile);
+    } catch (e) {
+        toastr.clear($progress_toast);
+        error(`Automated LTM analysis failed: ${e.message || e}`);
+        return;
     }
-
     toastr.clear($progress_toast);
 
-    if (had_error) return;
+    if (!result) {
+        error('Automated LTM analysis returned no result.');
+        return;
+    }
+
+    let content = result.content;
+    debug(`Automated LTM response: ${content}`);
+
+    let all_confirmed;
+    if (content.trim().toUpperCase() === 'NONE') {
+        all_confirmed = [];
+    } else {
+        let valid_set = new Set(valid_indexes);
+        all_confirmed = (content.match(/\d+/g)?.map(Number) || []).filter(n => valid_set.has(n));
+    }
+
+    if (all_confirmed === null) return;
 
     if (all_confirmed.length === 0) {
         log('Automated long-term memory analysis: no critically important messages identified.');

--- a/index.js
+++ b/index.js
@@ -3727,7 +3727,7 @@ async function analyze_long_term_memory_summary_chunk(chunk_lines, chunk_indexes
 
     let result;
     try {
-        result = await summarize_text(messages, profile);
+        result = await summaryQueue.summarize_text(messages, profile);
     } catch (e) {
         error(`Automated LTM chunk analysis failed: ${e.message || e}`);
         return null;

--- a/index.js
+++ b/index.js
@@ -3665,7 +3665,7 @@ function collect_long_term_memory_summaries(scope, end_index) {
 
     return { summary_lines, valid_indexes };
 }
-async function analyze_long_term_memory_chunk(chunk_lines, chunk_indexes, prompt_template, importance_text, profile) {
+async function analyze_long_term_memory_summary_chunk(chunk_lines, chunk_indexes, prompt_template, importance_text, profile) {
     // Send a single chunk of summary lines to the LLM and return the confirmed chat indexes.
     // Returns null on failure.
     let prompt_text = prompt_template
@@ -3765,7 +3765,7 @@ async function automated_long_term_memory(scope_override=null, end_index=null) {
         }
 
         debug(`Running automated LTM analysis${use_chunking ? ` (batch ${c + 1}/${total_chunks})` : ''}...`);
-        let confirmed = await analyze_long_term_memory_chunk(chunk.lines, chunk.indexes, prompt_template, importance_text, profile);
+        let confirmed = await analyze_long_term_memory_summary_chunk(chunk.lines, chunk.indexes, prompt_template, importance_text, profile);
 
         if (confirmed === null) {
             had_error = true;

--- a/index.js
+++ b/index.js
@@ -92,18 +92,6 @@ Following is a history of messages for context:
 Following is the message to summarize:
 {{message}}
 `
-const default_detailed_prompt = `Summarize the following fictional message as a single paragraph of 2-3 sentences in past tense. Do not use bullet points or numbered lists.
-Include: character names (not pronouns), actions taken, dialogue points, emotional shifts, decisions made, and new information revealed.
-
-{{#if history}}
-Recent summary context (for reference only, do not re-summarize):
-{{history}}
-{{/if}}
-
-Message to summarize:
-{{message}}
-
-Summary:`
 const default_automated_memory_prompt = `You are a narrative analysis assistant. Below is a list of message summaries from a fictional roleplay. Each line has this format: Message NUMBER | Long-term: Yes/No | Summary: TEXT
 
 {{summaries}}

--- a/index.js
+++ b/index.js
@@ -50,6 +50,7 @@ const PROGRESS_BAR_ID = `${MODULE_NAME}_progress_bar`;
 const css_message_div = `qvink_memory_display`
 const css_short_memory = `qvink_short_memory`
 const css_long_memory = `qvink_long_memory`
+const css_long_auto_memory = `qvink_long_auto_memory`
 const css_remember_memory = `qvink_old_memory`
 const css_exclude_memory = `qvink_exclude_memory`
 const css_lagging_memory = `qvink_lagging_memory`
@@ -73,6 +74,10 @@ const remember_button_class = `${MODULE_NAME}_remember_button`
 const summarize_button_class = `${MODULE_NAME}_summarize_button`
 const edit_button_class = `${MODULE_NAME}_edit_button`
 const forget_button_class = `${MODULE_NAME}_forget_button`
+const automated_memory_auto_button_class = `${MODULE_NAME}_automated_memory_auto_button`
+
+// Count new messages since last automated LTM run
+var automated_memory_auto_message_counter = 0
 
 // Settings
 const default_prompt = `You are a summarization assistant. Summarize the given fictional narrative in a single, very short and concise statement of fact.
@@ -88,6 +93,39 @@ Following is a history of messages for context:
 
 Following is the message to summarize:
 {{message}}
+`
+const default_automated_memory_prompt = `You are a narrative analysis assistant for an ongoing fictional roleplay. Your task: decide which message summaries should be preserved as long-term memories.
+
+The key test for each summary: does it introduce a fact, name, relationship detail, backstory, emotional development, or situation change that would be LOST if this summary were removed? If removing it would leave no gap in the story's record, it is not worth preserving.
+
+PRESERVE messages that introduce new information such as:
+- A character's name, identity, or backstory being revealed
+- New facts about a character's situation, history, or motivations
+- Relationship developments (friendships, conflicts, romance, alliances, betrayals, trust shifts)
+- Characters bonding, warming up to each other, or forming connections — or the opposite: growing hostile, distrustful, or distant — even through casual interaction
+- Characters observing or reacting to dynamics between others (e.g., a parent noticing someone bonding with their child, someone witnessing a confrontation or slight)
+- Events that change the characters' situation or the story's direction
+- Key decisions or commitments made by characters
+- New locations, setting details, or world-building facts
+- Conflicts being introduced or resolved
+- Changes in a character's status, abilities, or position
+- Promises, agreements, or plans characters make
+- Deaths, departures, or arrivals
+
+EXCLUDE messages that are:
+- Conversational scaffolding — questions, comments, or small talk that don't themselves reveal new facts or develop relationships (even if they prompt a reveal in the next message)
+- Redundant with another already-remembered summary (marked Long-term: Yes)
+- Purely transitional actions with no new narrative content
+- Minor reactions or internal thoughts that don't reveal anything new or shift any dynamic
+
+This is an ongoing story — you cannot know for certain what will matter later. When a summary contains new information, preserve it even if it seems minor now.
+
+Below are the message summaries to analyze. Each line has this format: Message NUMBER | Long-term: Yes/No | Summary: TEXT
+Messages already marked "Long-term: Yes" are examples of the kind of summary worth preserving — use them as a reference for the quality and relevance bar when evaluating unmarked messages.
+
+{{summaries}}
+
+Respond with ONLY the message numbers as a comma-separated list. Do not include any other text, explanation, or formatting. If no messages qualify, respond with the single word NONE.
 `
 const default_long_template = `[Following is a list of events that occurred in the past]:\n{{${generic_memories_macro}}}\n`
 const default_short_template = `[Following is a list of recent events]:\n{{${generic_memories_macro}}}\n`
@@ -107,11 +145,19 @@ const default_settings = {
 
     // summarization settings
     prompt: default_prompt,
+    automated_memory_prompt: default_automated_memory_prompt,
     summary_prompt_macros: default_summary_macros,  // macros for the summary prompt interface
     prompt_role: extension_prompt_roles.SYSTEM,
     prefill: "",   // summary prompt prefill
     show_prefill: false, // whether to show the prefill when memories are displayed
     connection_profile: "",  // connection profile to use for summarization. Empty ("") indicates the same as currently selected.
+
+    // automated long-term memory settings
+    automated_memory_scope: 'all',   // 'all' = all messages, 'new' = since last long-term memory, 'last_n' = last N messages
+    automated_memory_last_n: 50,   // number of messages to process when scope is 'last_n'
+    automated_memory_allow_removal: false,   // whether the analysis can also un-mark existing long-term memories
+    automated_memory_auto: false,   // whether to automatically trigger LTM analysis every N messages
+    automated_memory_auto_interval: 25,   // how many new messages between automatic LTM runs (minimum 10)
 
     auto_summarize: true,   // whether to automatically summarize new chat messages
     summarization_delay: 0,  // delay auto-summarization by this many messages (0 summarizes immediately after sending, 1 waits for one message, etc)
@@ -1042,6 +1088,13 @@ function refresh_settings() {
         get_settings_element('long_term_depth')?.parent().toggle(mid_chat)
         get_settings_element('long_term_role')?.parent().toggle(mid_chat)
 
+        // Disable the last_n input unless the last_n scope is selected
+        let scope = get_settings('automated_memory_scope');
+        get_settings_element('automated_memory_last_n')?.prop('disabled', scope !== 'last_n');
+
+        // Disable the interval input when auto LTM is off
+        let automated_memory_auto = get_settings('automated_memory_auto');
+        get_settings_element('automated_memory_auto_interval')?.prop('disabled', !automated_memory_auto);
 
     } else {  // memory is disabled for this chat
         $(`.${settings_content_class} .settings_input`).prop('disabled', true);  // disable all settings
@@ -1313,6 +1366,7 @@ async function delete_profile() {
         if (name === profile) {
             delete character_profiles[id]
         }
+        set_settings('character_profiles', character_profiles)
     }
     set_settings('character_profiles', character_profiles)
 
@@ -1422,12 +1476,16 @@ function get_message_div(index) {
 function get_summary_style_class(message) {
     let include = get_data(message, 'include');
     let remember = get_data(message, 'remember');
+    let remember_auto = get_data(message, 'remember_auto');
     let exclude = get_data(message, 'exclude');  // force-excluded by user
     let lagging = get_data(message, 'lagging');  // not injected yet
 
     let style = ""
     if (remember && include) {  // marked to be remembered and included in memory anywhere
         style = css_long_memory
+    }
+    else if (remember_auto && include) {  // marked to be remembered automatically and included in memory anywhere
+        style = css_long_auto_memory
     } else if (include === "short") {  // not marked to remember, but included in short-term memory
         style = css_short_memory
     } else if (remember) {  // marked to be remembered but not included in memory
@@ -1688,6 +1746,13 @@ class MemoryEditInterface {
             "default": true,
             "count": 0
         },
+        "long_term_auto": {
+            "title": "Summaries automatically tagged for long-term memory by automated analysis",
+            "display": "Long-Term (Auto)",
+            "check": (msg) => get_data(msg, 'remember_auto'),
+            "default": true,
+            "count": 0
+        },
         "excluded": {
             "title": "Summaries not in short-term or long-term memory",
             "display": "Forgot",
@@ -1775,6 +1840,7 @@ class MemoryEditInterface {
     <div><button id="bulk_exclude"    class="menu_button" title="Toggle inclusion of selected summaries from all memory">     <i class="fa-solid fa-ban"></i>Exclude</button></div>
     <div><button id="bulk_copy"       class="menu_button" title="Copy selected memories to clipboard">                        <i class="fa-solid fa-copy"></i>Copy</button></div>
     <div><button id="bulk_summarize"  class="menu_button" title="Re-Summarize selected memories">                             <i class="fa-solid fa-quote-left"></i>Summarize</button></div>
+    <div><button id="bulk_auto_ltm"   class="menu_button" title="Run automated long-term memory analysis on selected memories"><i class="fa-solid fa-wand-magic-sparkles"></i>Auto Long-Term</button></div>
     <div><button id="bulk_delete"     class="menu_button" title="Delete selected memories">                                   <i class="fa-solid fa-trash"></i>Delete</button></div>
     <div><button id="bulk_regex"      class="menu_button" title="Run the selected regex script on selected memories">         <i class="fa-solid fa-shuffle"></i>Regex Replace</button></div>
     <div><select id="regex_selector"  title="Choose regex script"></select>
@@ -1895,6 +1961,10 @@ class MemoryEditInterface {
         })
         this.$content.find(`#bulk_summarize`).on('click', async () => {
             await summaryQueue.summarize(this.get_sorted_selection());  // summarize in ascending order
+        })
+        this.$content.find(`#bulk_auto_ltm`).on('click', async () => {
+            await automated_long_term_memory(this.get_sorted_selection());
+            this.update_table();
         })
         this.$content.find(`#bulk_delete`).on('click', () => {
             this.get_sorted_selection().forEach(id => {
@@ -2025,6 +2095,7 @@ class MemoryEditInterface {
         let filter_no_summary = this.filter_bar.no_summary.filtered()
         let filter_short_term = this.filter_bar.short_term.filtered()
         let filter_long_term = this.filter_bar.long_term.filtered()
+        let filter_long_term_auto = this.filter_bar.long_term_auto.filtered()
         let filter_excluded = this.filter_bar.excluded.filtered()
         let filter_force_excluded = this.filter_bar.force_excluded.filtered()
         let filter_edited = this.filter_bar.edited.filtered()
@@ -2039,6 +2110,7 @@ class MemoryEditInterface {
 
             if (filter_short_term           && this.filter_bar.short_term.check(msg)) include = true;
             else if (filter_long_term       && this.filter_bar.long_term.check(msg)) include = true;
+            else if (filter_long_term_auto  && this.filter_bar.long_term_auto.check(msg)) include = true;
             else if (filter_no_summary      && this.filter_bar.no_summary.check(msg)) include = true;
             else if (filter_errors          && this.filter_bar.errors.check(msg)) include = true;
             else if (filter_excluded        && this.filter_bar.excluded.check(msg)) include = true;
@@ -2494,7 +2566,9 @@ class SummaryPromptEditInterface {
         // buttons
         this.$preview.on('click', () => this.preview_prompt())
         this.$add_macro.on('click', () => this.new_macro())
-        this.$restore.on('click', () => this.$prompt.val(default_settings["prompt"]))
+        this.$restore.on('click', () => {
+            this.$prompt.val(default_settings["prompt"]);
+        })
         this.$open_macros.on('click', () => {
             this.$content.find('.toggle-macro').toggle()
         })
@@ -3616,6 +3690,7 @@ async function remember_message_toggle(indexes=null, value=null) {
         let message = context.chat[index]
         set_data(message, 'remember', value);
         set_data(message, 'exclude', false);  // regardless, remove excluded flag
+        set_data(message, 'remember_auto', false);  // always clear auto flag when manually toggling
 
         let memory = get_data(message, 'memory')
         if (value && !memory) {
@@ -3635,6 +3710,174 @@ async function remember_message_toggle(indexes=null, value=null) {
         await summaryQueue.summarize(summarize);
     }
     refresh_memory();
+}
+async function remember_auto_message_toggle(indexes=null, value=null) {
+    // Toggle the "remember_auto" (automated long-term memory) status of a set of messages.
+    // Messages already manually tagged with 'remember' are never touched.
+    let context = getContext();
+
+    if (!Array.isArray(indexes)) {
+        indexes = [indexes]
+    } else if (indexes === null) {
+        indexes = [Math.max(context.chat.length-1, 0)]
+    }
+
+    // Filter out any messages already manually marked as long-term
+    indexes = indexes.filter(i => !get_data(context.chat[i], 'remember'));
+
+    let summarize = [];
+
+    function set(index, val) {
+        let message = context.chat[index]
+        set_data(message, 'remember_auto', val);
+        set_data(message, 'exclude', false);
+
+        let memory = get_data(message, 'memory')
+        if (val && !memory) {
+            summarize.push(index)
+        }
+        debug(`Set message ${index} remember_auto status: ${val}`);
+    }
+
+    function check(index) {
+        return get_data(context.chat[index], 'remember_auto')
+    }
+
+    toggle_memory_value(indexes, value, check, set)
+
+    if (summarize.length > 0) {
+        await summaryQueue.summarize(summarize);
+    }
+    refresh_memory();
+}
+function collect_ltm_scope_indexes(scope, end_index) {
+    // Return all chat indexes within the scope window (not filtered by whether they have a summary).
+    let chat = getContext().chat;
+    let last_index = end_index ?? chat.length - 1;
+    let start_index = 0;
+
+    // Start from the most recent long-term memory (searching back from last_index)
+    if (scope === 'new') {
+        for (let i = last_index; i >= 0; i--) {
+            if (get_data(chat[i], 'remember') || get_data(chat[i], 'remember_auto')) {
+                start_index = i;
+                break;
+            }
+        }
+    // Count back N summarized messages from last_index
+    } else if (scope === 'last_n') {
+        let n = get_settings('automated_memory_last_n') || 50;
+        let count = 0;
+        for (let i = last_index; i >= 0; i--) {
+            if (get_data(chat[i], 'memory')) {
+                count++;
+                if (count >= n) {
+                    start_index = i;
+                    break;
+                }
+            }
+        }
+    }
+
+    let indexes = [];
+    for (let i = start_index; i <= last_index; i++) indexes.push(i);
+    return indexes;
+}
+function build_ltm_summary_lines(indexes) {
+    // Given a list of chat indexes, return formatted summary lines and the subset of indexes
+    // that actually have a summary, for passing to the LLM.
+    let chat = getContext().chat;
+    let summary_lines = [];
+    let valid_indexes = [];
+    for (let i of indexes) {
+        let memory = get_data(chat[i], 'memory');
+        if (!memory) continue;
+        let is_remembered = (get_data(chat[i], 'remember') || get_data(chat[i], 'remember_auto')) ? 'Yes' : 'No';
+        summary_lines.push(`Message ${i} | Long-term: ${is_remembered} | Summary: ${memory}`);
+        valid_indexes.push(i);
+    }
+    return { summary_lines, valid_indexes };
+}
+async function automated_long_term_memory(indexes=null, end_index=null) {
+    // Use an LLM to identify critically important summaries and mark them as long-term memories.
+    // indexes: if provided, analyse exactly these message indexes instead of deriving a scope window
+    // end_index: if provided, treat this as the latest message (inclusive) instead of the end of the chat
+    let chat = getContext().chat;
+
+    // Step 1: Collect summaries — either from explicit indexes or by deriving a scope window
+    let scope_indexes = indexes ?? collect_ltm_scope_indexes(get_settings('automated_memory_scope'), end_index);
+    let { summary_lines, valid_indexes } = build_ltm_summary_lines(scope_indexes);
+
+    if (summary_lines.length === 0) {
+        log('No summaries found for automated long-term memory analysis.');
+        toastr.warning('No summarized messages found to analyze.', MODULE_NAME_FANCY);
+        return;
+    }
+
+    // Step 2: Send summaries to the LLM for analysis
+    let prompt_text = get_settings('automated_memory_prompt').replace('{{summaries}}', summary_lines.join('\n'));
+    let messages = [{role: 'system', content: prompt_text}];
+    let profile = get_summary_connection_profile();
+
+    let $progress_toast = toastr.info(`Analyzing ${summary_lines.length} message summaries...`, MODULE_NAME_FANCY, { timeOut: 0, extendedTimeOut: 0, tapToDismiss: false });
+    debug('Running automated LTM analysis...');
+    let result;
+    try {
+        result = await summaryQueue.summarize_text(messages, profile);
+    } catch (e) {
+        toastr.clear($progress_toast);
+        error(`Automated LTM analysis failed: ${e.message || e}`);
+        return;
+    }
+    toastr.clear($progress_toast);
+
+    if (!result) {
+        error('Automated LTM analysis returned no result.');
+        return;
+    }
+
+    let content = result.content;
+    debug(`Automated LTM response: ${content}`);
+
+    let all_confirmed;
+    if (content.trim().toUpperCase() === 'NONE') {
+        all_confirmed = [];
+    } else {
+        let valid_set = new Set(valid_indexes);
+        all_confirmed = (content.match(/\d+/g)?.map(Number) || []).filter(n => valid_set.has(n));
+    }
+
+    if (all_confirmed === null) return;
+
+    if (all_confirmed.length === 0) {
+        log('Automated long-term memory analysis: no critically important messages identified.');
+        toastr.info('Analysis complete — no messages were identified as critically important.', MODULE_NAME_FANCY);
+        return;
+    }
+
+    debug(`Automated LTM marking messages as long-term: ${all_confirmed.join(', ')}`);
+
+    // Step 5: Mark confirmed messages as long-term, and optionally remove the flag from others
+    let confirmed_set = new Set(all_confirmed);
+
+    // Count only messages not already marked before toggling, so the toast reflects newly marked messages
+    let newly_marked_count = all_confirmed.filter(i => !get_data(chat[i], 'remember') && !get_data(chat[i], 'remember_auto')).length;
+    await remember_auto_message_toggle(all_confirmed, true);
+
+    let removed_count = 0;
+    if (get_settings('automated_memory_allow_removal')) {
+        let to_remove = valid_indexes.filter(i => !confirmed_set.has(i) && get_data(chat[i], 'remember_auto'));
+        if (to_remove.length > 0) {
+            debug(`Automated LTM removing long-term flag from messages: ${to_remove.join(', ')}`);
+            await remember_auto_message_toggle(to_remove, false);
+            removed_count = to_remove.length;
+        }
+    }
+
+    let summary_msg = `Long-term memory updated — ${newly_marked_count} message${newly_marked_count !== 1 ? 's' : ''} newly marked as important.`;
+    if (removed_count > 0) summary_msg += ` ${removed_count} removed.`;
+    toastr.success(summary_msg, MODULE_NAME_FANCY);
+    log(summary_msg);
 }
 function forget_message_toggle(indexes=null, value=null) {
     // Toggle the "forget" status of a message
@@ -3863,7 +4106,7 @@ function update_message_inclusion_flags() {
             }
 
             // consider this for short term memories as long as we aren't separating long-term or (if we are), this isn't a long-term
-            if (!separate_long_term || !get_data(message, 'remember')) {
+            if (!separate_long_term || (!get_data(message, 'remember') && !get_data(message, 'remember_auto'))) {
                 let new_short_token_size = short_token_size + sep_size + count_tokens(get_memory(message))
                 if (new_short_token_size > short_token_limit) {  // over context limit
                     short_limit_reached = true;
@@ -3876,7 +4119,7 @@ function update_message_inclusion_flags() {
         }
 
         // if the short-term limit has been reached (or we are separating), check the long-term limit.
-        let remember = get_data(message, 'remember');
+        let remember = get_data(message, 'remember') || get_data(message, 'remember_auto');
         if (!long_limit_reached && remember) {  // long-term limit hasn't been reached yet and the message was marked to be remembered
             let new_long_token_size = long_token_size + sep_size + count_tokens(get_memory(message))
             if (new_long_token_size > long_token_limit) {  // over context limit
@@ -4099,6 +4342,21 @@ async function auto_summarize_chat(skip_initial_delay=true) {
     await summaryQueue.summarize(messages_to_summarize, skip_initial_delay, show_progress);
 }
 
+async function check_automated_memory_auto_trigger() {
+    // Increment the message counter and fire automated_long_term_memory if the interval has been reached
+    if (!get_settings('automated_memory_auto') || !chat_enabled()) return;
+
+    automated_memory_auto_message_counter++;
+    let interval = Math.max(10, get_settings('automated_memory_auto_interval') || 25);
+    debug(`Auto LTM counter: ${automated_memory_auto_message_counter} / ${interval}`);
+
+    if (automated_memory_auto_message_counter >= interval) {
+        automated_memory_auto_message_counter = 0;
+        log('Auto LTM interval reached, running automated long-term memory analysis...');
+        await automated_long_term_memory();
+    }
+}
+
 // Event handling
 var last_message_swiped = null;  // if an index, that was the last message swiped
 var last_message = null; // if an index, that was the last message sent
@@ -4125,6 +4383,7 @@ async function on_chat_event(event=null, data=null) {
 
 
             reset_injection_threshold()
+            automated_memory_auto_message_counter = 0;  // reset counter on chat change
             auto_load_profile();  // load the profile for the current chat or character
             refresh_memory();  // refresh the memory state
             if (context?.chat?.length) {
@@ -4165,6 +4424,12 @@ async function on_chat_event(event=null, data=null) {
             last_message_swiped = null;
             last_message = null;
             if (!chat_enabled()) break;  // if chat is disabled, do nothing
+
+            // Count user messages toward auto LTM if user messages are included in summarization
+            if (get_settings('include_user_messages')) {
+                await check_automated_memory_auto_trigger();
+            }
+
             if (!get_settings('auto_summarize')) break;  // if auto-summarize is disabled, do nothing
             if (just_opened || just_aborted) break;  // don't auto-summarize if just opened the chat
 
@@ -4201,6 +4466,7 @@ async function on_chat_event(event=null, data=null) {
                 refresh_memory()
             } else { // not a swipe or continue
                 last_message_swiped = null
+                await check_automated_memory_auto_trigger();  // count new char message toward auto LTM
                 if (!get_settings('auto_summarize')) break;  // if auto-summarize is disabled, do nothing
                 if (get_settings("auto_summarize_on_send")) break;  // if auto_summarize_on_send is enabled, don't auto-summarize on character message
                 debug("New message detected, summarizing")
@@ -4277,6 +4543,14 @@ function initialize_settings_listeners() {
     bind_function('#stop_summarization', () => summaryQueue.stop());
     bind_function('#revert_settings', reset_settings);
 
+    bind_function('#edit_automated_memory_prompt', async () => {
+        let description = `
+<ul style="text-align: left; font-size: smaller;">
+    <li>This prompt is sent to the LLM with all message summaries to identify critically important long-term memories.</li>
+    <li><b>{{summaries}}</b> will be replaced with the formatted list of message summaries.</li>
+</ul>`
+        get_user_setting_text_input('automated_memory_prompt', t`Edit Automated Memory Prompt`, description)
+    })
     bind_function('#toggle_chat_memory', () => toggle_chat_enabled(), false);
     bind_function('#edit_memory_state', () => memoryEditInterface.show())
     bind_function("#refresh_memory", () => refresh_memory());
@@ -4347,6 +4621,12 @@ function initialize_settings_listeners() {
     bind_setting('#long_term_context_limit', 'long_term_context_limit', 'number')
     bind_setting('#long_term_context_type', 'long_term_context_type', 'text')
 
+    bind_setting('input[name="automated_memory_scope"]', 'automated_memory_scope', 'text');
+    bind_setting('#automated_memory_last_n', 'automated_memory_last_n', 'number');
+    bind_setting('#automated_memory_allow_removal', 'automated_memory_allow_removal', 'boolean');
+    bind_setting('#automated_memory_auto', 'automated_memory_auto', 'boolean');
+    bind_setting('#automated_memory_auto_interval', 'automated_memory_auto_interval', 'number');
+
     bind_setting('#debug_mode', 'debug_mode', 'boolean');
     bind_setting('#display_memories', 'display_memories', 'boolean')
     bind_setting('#default_chat_enabled', 'default_chat_enabled', 'boolean');
@@ -4364,6 +4644,7 @@ function initialize_message_buttons() {
     let ctx = getContext()
 
     let html = `
+<div title="${t`Process Long-Term Memory (analyze all summaries and automatically tag critically important messages for long-term memory)`}" class="mes_button ${automated_memory_auto_button_class} fa-solid fa-cloud-bolt" tabindex="0"></div>
 <div title="${t`Remember (toggle inclusion of summary in long-term memory)`}" class="mes_button ${remember_button_class} fa-solid fa-brain" tabindex="0"></div>
 <div title="${t`Force Exclude (toggle inclusion of summary from all memory)`}" class="mes_button ${forget_button_class} fa-solid fa-ban" tabindex="0"></div>
 <div title="${t`Edit Summary`}" class="mes_button ${edit_button_class} fa-solid fa-pen-fancy" tabindex="0"></div>
@@ -4375,6 +4656,11 @@ function initialize_message_buttons() {
 
     // button events
     let $chat = $("div#chat")
+    $chat.on("click", `.${automated_memory_auto_button_class}`, async function () {
+        const message_block = $(this).closest(".mes");
+        const message_id = Number(message_block.attr("mesid"));
+        await automated_long_term_memory(null, message_id);
+    });
     $chat.on("click", `.${remember_button_class}`, async function () {
         const message_block = $(this).closest(".mes");
         const message_id = Number(message_block.attr("mesid"));

--- a/settings.html
+++ b/settings.html
@@ -310,6 +310,44 @@
                     </select>
                 </label>
 
+                <!-- Automated Long-term memory -->
+                <hr>
+                <h4 class="textAlignCenter">Automated Long-Term Memory <i class="fa-solid fa-info-circle" title="Settings that control how automated long-term memory analysis works when triggered."></i></h4>
+                <div class="flex-container justifyspacebetween alignitemscenter">
+                    <button id="edit_automated_memory_prompt" class="menu_button flex1" title="Edit the prompt used to analyze summaries and identify critically important long-term memories."><span>Edit</span></button>
+                </div>
+
+
+                <label title="When enabled, the analysis can also remove the long-term memory flag from previously tagged messages that are no longer considered important in the broader context of the narrative." class="checkbox_label">
+                    <input id="automated_memory_allow_removal" type="checkbox" />
+                    <span>Allow Long-Term Memory Removal</span>
+                </label>
+
+                <label title="When enabled, long-term memory analysis runs automatically after every N new messages using the scope selected above. For example, with scope set to 'Process Last 50 Memories' and interval set to 25, the last 50 messages are analyzed every 25 messages — overlap is intentional and helps ensure nothing important is missed." class="checkbox_label">
+                    <input id="automated_memory_auto" type="checkbox" />
+                    <span>Auto-Process Long-Term Memory</span>
+                </label>
+                <label title="How many new messages must arrive before automatically triggering long-term memory analysis. Minimum 10. This controls how often analysis runs, not how many messages are analyzed — that is determined by the scope setting above." class="checkbox_label">
+                    <input id="automated_memory_auto_interval" class="text_pole widthUnset inline_setting" type="number" min="10" max="999" />
+                    <span>Memory Interval</span>
+                </label>
+
+                <div class="radio_group">
+                    <label title="Analyze all summarized messages to find any that should be promoted to long-term memory.">
+                        <input type="radio" name="automated_memory_scope" value="all" />
+                        <span>Process All Memories</span>
+                    </label>
+                    <label title="Only analyze messages from the most recent long-term memory entry up to the latest message. Useful for incremental updates without reprocessing the full history.">
+                        <input type="radio" name="automated_memory_scope" value="new" />
+                        <span>Process New Memories</span>
+                    </label>
+                    <label title="Only analyze the last N summarized messages. Useful for large chats where processing everything would be expensive.">
+                        <input type="radio" name="automated_memory_scope" value="last_n" />
+                        <span>Process Last</span>
+                        <input id="automated_memory_last_n" class="text_pole widthUnset inline_setting" type="number" min="1" max="999" />
+                        <span>Memories</span>
+                    </label>
+                </div>
 
                 <!-- Misc. -->
                 <hr>

--- a/settings.html
+++ b/settings.html
@@ -310,6 +310,55 @@
                     </select>
                 </label>
 
+                <!-- Automated Long-term memory -->
+                <hr>
+                <h4 class="textAlignCenter">Automated Long-Term Memory <i class="fa-solid fa-info-circle" title="Settings that control how automated long-term memory analysis works when triggered."></i></h4>
+
+                <div class="flex-container justifyspacebetween alignitemscenter">
+                    <button id="edit_automated_memory_prompt" class="menu_button flex1" title="Edit the prompt used to analyze summaries and identify critically important long-term memories."><span>Edit</span></button>
+                    <button id="process_all_ltm" class="menu_button flex1" title="Analyze all summarized messages and tag critically important ones as long-term memories. When scope is set to 'Process All Memories', all messages are sent in a single batch. Otherwise, messages are processed in batches using the 'Process Last N Memories' value as the chunk size. Respects the Allow Long-Term Memory Removal setting."><span>Process All Memories</span></button>
+                </div>
+
+                <label title="Controls how selective the LLM is when choosing which messages to preserve. High keeps only major turning points, Medium keeps significant developments, Low preserves most meaningful content. None adds no additional guidance to the prompt." class="checkbox_label">
+                    <span>Importance Threshold: </span>
+                    <select id="automated_memory_importance" class="text_pole inline_setting">
+                        <option value="none">None</option>
+                        <option value="high">High</option>
+                        <option value="medium">Medium</option>
+                        <option value="low">Low</option>
+                    </select>
+                </label>
+
+                <label title="When enabled, the analysis can also remove the long-term memory flag from previously tagged messages that are no longer considered important in the broader context of the narrative." class="checkbox_label">
+                    <input id="automated_memory_allow_removal" type="checkbox" />
+                    <span>Allow Long-Term Memory Removal</span>
+                </label>
+
+                <label title="When enabled, long-term memory analysis runs automatically after every N new messages using the scope selected above. For example, with scope set to 'Process Last 50 Memories' and interval set to 25, the last 50 messages are analyzed every 25 messages — overlap is intentional and helps ensure nothing important is missed." class="checkbox_label">
+                    <input id="automated_memory_auto" type="checkbox" />
+                    <span>Auto-Process Long-Term Memory</span>
+                </label>
+                <label title="How many new messages must arrive before automatically triggering long-term memory analysis. Minimum 10. This controls how often analysis runs, not how many messages are analyzed — that is determined by the scope setting above." class="checkbox_label">
+                    <input id="automated_memory_auto_interval" class="text_pole widthUnset inline_setting" type="number" min="10" max="999" />
+                    <span>Memory Interval</span>
+                </label>
+
+                <div class="radio_group">
+                    <label title="Analyze all summarized messages to find any that should be promoted to long-term memory.">
+                        <input type="radio" name="automated_memory_scope" value="all" />
+                        <span>Process All Memories</span>
+                    </label>
+                    <label title="Only analyze messages from the most recent long-term memory entry up to the latest message. Useful for incremental updates without reprocessing the full history.">
+                        <input type="radio" name="automated_memory_scope" value="new" />
+                        <span>Process New Memories</span>
+                    </label>
+                    <label title="Only analyze the last N summarized messages. Useful for large chats where processing everything would be expensive.">
+                        <input type="radio" name="automated_memory_scope" value="last_n" />
+                        <span>Process Last</span>
+                        <input id="automated_memory_last_n" class="text_pole widthUnset inline_setting" type="number" min="1" max="999" />
+                        <span>Memories</span>
+                    </label>
+                </div>
 
                 <!-- Misc. -->
                 <hr>

--- a/settings.html
+++ b/settings.html
@@ -313,8 +313,10 @@
                 <!-- Automated Long-term memory -->
                 <hr>
                 <h4 class="textAlignCenter">Automated Long-Term Memory <i class="fa-solid fa-info-circle" title="Settings that control how automated long-term memory analysis works when triggered."></i></h4>
+                <div class="flex-container justifyspacebetween alignitemscenter">
+                    <button id="edit_automated_memory_prompt" class="menu_button" title="Edit the prompt used to analyze summaries and identify critically important long-term memories."><span>Edit Prompt</span></button>
+                </div>
 
-                <button id="edit_automated_memory_prompt" class="menu_button" title="Edit the prompt used to analyze summaries and identify critically important long-term memories."><span>Edit Prompt</span></button>
 
                 <label title="When enabled, the analysis can also remove the long-term memory flag from previously tagged messages that are no longer considered important in the broader context of the narrative." class="checkbox_label">
                     <input id="automated_memory_allow_removal" type="checkbox" />

--- a/settings.html
+++ b/settings.html
@@ -319,16 +319,6 @@
                     <button id="process_all_ltm" class="menu_button flex1" title="Analyze all summarized messages and tag critically important ones as long-term memories. When scope is set to 'Process All Memories', all messages are sent in a single batch. Otherwise, messages are processed in batches using the 'Process Last N Memories' value as the chunk size. Respects the Allow Long-Term Memory Removal setting."><span>Process All Memories</span></button>
                 </div>
 
-                <label title="Controls how selective the LLM is when choosing which messages to preserve. High keeps only major turning points, Medium keeps significant developments, Low preserves most meaningful content. None adds no additional guidance to the prompt." class="checkbox_label">
-                    <span>Importance Threshold: </span>
-                    <select id="automated_memory_importance" class="text_pole inline_setting">
-                        <option value="none">None</option>
-                        <option value="high">High</option>
-                        <option value="medium">Medium</option>
-                        <option value="low">Low</option>
-                    </select>
-                </label>
-
                 <label title="When enabled, the analysis can also remove the long-term memory flag from previously tagged messages that are no longer considered important in the broader context of the narrative." class="checkbox_label">
                     <input id="automated_memory_allow_removal" type="checkbox" />
                     <span>Allow Long-Term Memory Removal</span>

--- a/settings.html
+++ b/settings.html
@@ -314,10 +314,7 @@
                 <hr>
                 <h4 class="textAlignCenter">Automated Long-Term Memory <i class="fa-solid fa-info-circle" title="Settings that control how automated long-term memory analysis works when triggered."></i></h4>
 
-                <div class="flex-container justifyspacebetween alignitemscenter">
-                    <button id="edit_automated_memory_prompt" class="menu_button flex1" title="Edit the prompt used to analyze summaries and identify critically important long-term memories."><span>Edit</span></button>
-                    <button id="process_all_ltm" class="menu_button flex1" title="Analyze all summarized messages and tag critically important ones as long-term memories. When scope is set to 'Process All Memories', all messages are sent in a single batch. Otherwise, messages are processed in batches using the 'Process Last N Memories' value as the chunk size. Respects the Allow Long-Term Memory Removal setting."><span>Process All Memories</span></button>
-                </div>
+                <button id="edit_automated_memory_prompt" class="menu_button" title="Edit the prompt used to analyze summaries and identify critically important long-term memories."><span>Edit Prompt</span></button>
 
                 <label title="When enabled, the analysis can also remove the long-term memory flag from previously tagged messages that are no longer considered important in the broader context of the narrative." class="checkbox_label">
                     <input id="automated_memory_allow_removal" type="checkbox" />

--- a/settings.html
+++ b/settings.html
@@ -314,7 +314,7 @@
                 <hr>
                 <h4 class="textAlignCenter">Automated Long-Term Memory <i class="fa-solid fa-info-circle" title="Settings that control how automated long-term memory analysis works when triggered."></i></h4>
                 <div class="flex-container justifyspacebetween alignitemscenter">
-                    <button id="edit_automated_memory_prompt" class="menu_button" title="Edit the prompt used to analyze summaries and identify critically important long-term memories."><span>Edit Prompt</span></button>
+                    <button id="edit_automated_memory_prompt" class="menu_button flex1" title="Edit the prompt used to analyze summaries and identify critically important long-term memories."><span>Edit</span></button>
                 </div>
 
 

--- a/style.css
+++ b/style.css
@@ -316,6 +316,9 @@ dialog:has(#qvink_memory_state_interface) {
 #qvink_memory_state_interface #bulk_summarize  {
     color: red;
 }
+#qvink_memory_state_interface #bulk_auto_ltm  {
+    color: red;
+}
 #qvink_memory_state_interface #regex_selector  {
     margin: 0;
 }

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
     --qm-default: grey;
     --qm-short: #2E8B57;
     --qm-long: #4682B4;
+    --qm-long-auto: #46b4b0;
     --qm-old: #8B0000;
     --qm-excluded: #555;
     --qm-redundant-opacity: 50%;
@@ -79,6 +80,14 @@ By default, text is greyed to indicate that is it not injected.
 }
 .qvink_long_memory.qvink_lagging_memory {
     color: rgba(from var(--qm-long) r g b / var(--qm-redundant-opacity));
+    text-shadow: none;
+}
+/* to style long-term memories. */
+.qvink_long_auto_memory {
+    color: var(--qm-long-auto);
+}
+.qvink_long_auto_memory.qvink_lagging_memory {
+    color: rgba(from var(--qm-long-auto) r g b / var(--qm-redundant-opacity));
     text-shadow: none;
 }
 /* to style memories marked for long-term, but are past the context limit */

--- a/style.css
+++ b/style.css
@@ -2,6 +2,7 @@
     --qm-default: grey;
     --qm-short: #2E8B57;
     --qm-long: #4682B4;
+    --qm-long-auto: #46b4b0;
     --qm-old: #8B0000;
     --qm-excluded: #555;
     --qm-redundant-opacity: 50%;
@@ -80,6 +81,14 @@ By default, text is greyed to indicate that is it not injected.
 }
 .qvink_long_memory.qvink_lagging_memory {
     color: rgba(from var(--qm-long) r g b / var(--qm-redundant-opacity));
+    text-shadow: none;
+}
+/* to style long-term memories. */
+.qvink_long_auto_memory {
+    color: var(--qm-long-auto);
+}
+.qvink_long_auto_memory.qvink_lagging_memory {
+    color: rgba(from var(--qm-long-auto) r g b / var(--qm-redundant-opacity));
     text-shadow: none;
 }
 /* to style memories marked for long-term, but are past the context limit */
@@ -311,6 +320,9 @@ dialog:has(#qvink_memory_state_interface) {
 #qvink_memory_state_interface #bulk_regex,
 #qvink_memory_state_interface #bulk_delete,
 #qvink_memory_state_interface #bulk_summarize  {
+    color: red;
+}
+#qvink_memory_state_interface #bulk_auto_ltm  {
     color: red;
 }
 #qvink_memory_state_interface #regex_selector  {


### PR DESCRIPTION
Thought I would propose this idea that I had for an "Automated Long-Term Memory" solution. I use qvink in a style where I have it produce slightly more useful summaries over time, but this fills up the short-term context quicker. In longer chats this can lead to sort of a run-out where useful information tends to trickle off unless I'm actively thinking and tagging summaries. For me I usually forget to do this and would end up having to go back and try to determine `what is actually relevant`.

There's always a lot of "filler" messages no matter what anyone does, and the characters don't need to remember the filler, it's really not important overall in the long term (and the user will probably forget it anyways), but key moments really matter.

So I had an idea to work on this today and sort of got lost in the implementation and testing and thought I would at least throw it out as a concept for you to consider.

# What's in this PR
- Added a secondary default option that is better suited for prioritizing long term summarization flows
- Added the automated long term summarization system (see the README.md) for the main ideas but it has the following additions:
  - We collect all relevant message (either all, everything since the last long term message, or the last N messages)
  - Determine if we are using 1 or more chunks
  - Process chunks and get back indexes that should be flagged for long term
  - Flag the messages for long term storage
  - [Optional] We can unflag memories if a setting is selected
- We can also automatically run this every N messages for the user
- There is a small interesting tweak which alters the wording to try and determine what the LLM thinks is "important". After a lot of refinement this actually works pretty well, with High excluding a lot and Low being pretty generous about what is "important".
- There is a batch operation to allow the user to trigger the entire flow on everything
- On each message is a small Lightning Bolt Cloud icon. If you click this it assumes that message it the "most recent" message so it will trigger from there backwards in your chat. This can allow you to "reprocess" specific areas.
- Updated the `settings.html` to have the relevant settings and I tried to add really clear tooltips about what is happening here.


**Notably this doesn't really "change" Qvink_memory in much of a visual manner, it's more an automated backend functionality that is designed to streamline the concept of long term memory if a user is interested in doing that.**


# Testing
I tested this with GLM, DeepSeek, Claude and a few others. I worked to try and refine the prompts themselves (Using Clause Opus) so that they are appropriate for usage with Flash models (spent a while going back and forth with it trying to get it to think like a simpler model and tell me where it struggled). This led to prompts which are actually pretty reliable.

Overall I have actually been pretty please with the results, and its nice to not really have to "think" about the long term memory and just let the LLM determine what is actually important or not.

So this is mainly tuned towards "Flash" style models, but it works fine with the non-flash ones as well. It does generally select what I would consider the important message across several chats that I post processed and running it on new chats.

# Screenshots
Message Changes:
<img width="409" height="97" alt="Screenshot 2026-03-18 at 4 28 59 PM" src="https://github.com/user-attachments/assets/c10b120d-0c6a-47e3-bf9d-29320a359764" />

New Settings:
<img width="775" height="285" alt="Screenshot 2026-03-18 at 4 28 42 PM" src="https://github.com/user-attachments/assets/53577560-6398-44f0-9473-39643f459bc3" />

New Prompt for Auto Long-Term:
<img width="763" height="657" alt="Screenshot 2026-03-18 at 4 28 49 PM" src="https://github.com/user-attachments/assets/94ef39ce-e505-42be-be87-4ee596e4b05d" />

Summary Prompt Changes:
<img width="390" height="111" alt="Screenshot 2026-03-18 at 4 33 10 PM" src="https://github.com/user-attachments/assets/5d67c7cc-8ef3-4d51-8129-842a1e9d5080" />
<img width="433" height="185" alt="Screenshot 2026-03-18 at 4 33 15 PM" src="https://github.com/user-attachments/assets/2b3eb467-1f46-4eef-a079-9fb165712768" />

